### PR TITLE
Add governance and repository lifecycle foundation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability or sensitive report
+    url: https://github.com/hackelia-micrantha/.github/security/policy
+    about: Follow the private disclosure guidance. Do not place exploit details, credentials, secrets, or sensitive data in a public issue.
+  - name: Work-item and decision guidance
+    url: https://github.com/hackelia-micrantha/.github/blob/main/docs/engineering/work-items.md
+    about: Choose between a bug, feature, delivery slice, design proposal, epic, QART analysis, RFC, ADR, or investigation.
+  - name: Support guidance
+    url: https://github.com/hackelia-micrantha/.github/blob/main/.github/SUPPORT.md
+    about: Review the organization support guidance before filing a request that is not an actionable repository issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,38 +1,94 @@
-## Summary
-Describe what this PR changes and why.
+## Outcome
+
+Describe the observable result this pull request delivers and why it matters.
+
+## Related work and authority
+
+- **Issue, epic, RFC, ADR, incident, or release:**
+- **Authoritative repository or contract affected:**
+- **Decision or approval already established:**
+
+Use `None` when genuinely not applicable. Do not imply that this pull request itself accepts an unresolved architectural decision or residual security risk.
 
 ## Scope
-- [ ] Bug fix
-- [ ] Feature
-- [ ] Refactor
-- [ ] Documentation
-- [ ] Security / hardening
-- [ ] Build / CI
 
-## Design notes
-- Key decisions:
-- Alternatives considered:
-- Tradeoffs:
+### In scope
 
-## Testing
-- [ ] Unit tests
-- [ ] Integration tests
-- [ ] Manual verification
-- [ ] Not applicable
+- Required change or behavior
 
-Provide details:
-- Steps:
-- Commands:
-- Screenshots/logs (if relevant):
+### Non-goals
 
-## Security & operational impact
-- Threat surface changes:
-- Secrets/config considerations:
-- Observability/monitoring updates:
-- Rollback plan (if relevant):
+- Adjacent or follow-up work intentionally excluded
 
-## Checklist
-- [ ] I kept the change as small as practical.
-- [ ] I updated docs/comments where needed.
-- [ ] I added/updated tests where appropriate.
-- [ ] I did not include secrets in code or logs.
+## Implementation and design notes
+
+- Key implementation choices:
+- Existing contracts or invariants preserved:
+- Alternatives or trade-offs relevant to review:
+- Cross-repository, provider, platform, or deployment effects:
+
+## Validation evidence
+
+List the actual evidence produced. Do not check a category solely because a test file exists.
+
+- [ ] Formatting or linting
+- [ ] Unit or component tests
+- [ ] Contract or integration tests
+- [ ] End-to-end or manual demonstration
+- [ ] Security, negative-path, or failure-path validation
+- [ ] Compatibility, migration, or rollback validation
+- [ ] Documentation-only review; runtime validation is not applicable
+
+**Commands, checks, runs, artifacts, screenshots, or results:**
+
+- 
+
+**Evidence not available or intentionally deferred:**
+
+- 
+
+## Security and governance impact
+
+- Trust, authorization, approval, execution, or data-boundary changes:
+- Secret, credential, personal-data, or sensitive-log handling:
+- Dependency, artifact, runner, or supply-chain impact:
+- Residual risk and accountable acceptance owner, if any:
+- Anthesis or other governance-policy implications, if applicable:
+
+Use `No material change` only after considering the relevant boundaries.
+
+## Compatibility, migration, rollout, and rollback
+
+- Existing consumers and mixed-version behavior:
+- Configuration, schema, data, API, CLI, or artifact migration:
+- Deployment or staged rollout:
+- Rollback, recovery, or irreversibility:
+
+## Documentation, release, and public claims
+
+- Documentation updated:
+- Changelog, version, release, or provenance impact:
+- Public site, README, maturity, support, or compatibility claims affected:
+
+## Remaining work
+
+- Follow-up issues or explicitly deferred work:
+- Does this PR close the stated outcome? Yes / No — explain when `No`.
+
+## Author checklist
+
+- [ ] The change is bounded and belongs in this repository.
+- [ ] The pull request advances a documented outcome or clearly explains why no issue is needed.
+- [ ] Unresolved decisions use QART or RFC rather than being hidden in implementation.
+- [ ] Durable accepted decisions are recorded in ADRs when appropriate.
+- [ ] Relevant tests and evidence cover primary and material failure paths.
+- [ ] Required checks were not weakened merely to obtain a green result.
+- [ ] Documentation and public claims match the resulting implementation.
+- [ ] No credentials, secrets, private customer data, or sensitive vulnerability details are exposed.
+- [ ] Remaining work is captured separately rather than concealed by the merge.
+
+## Reviewer focus
+
+Call out the areas where reviewer attention is most valuable:
+
+- 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,195 @@
+# Micrantha governance
+
+This document defines the default governance model for repositories and projects in the `hackelia-micrantha` organization. It establishes decision authority, repository ownership, lifecycle control, security-risk acceptance, and accountable use of AI-assisted engineering.
+
+A repository may refine these defaults when its product, legal, security, or operating model requires it. Any override must be explicit, discoverable, and no weaker than an applicable organization-wide security or legal requirement.
+
+## Principles
+
+1. **Authority is explicit.** A recommendation, implementation, merged pull request, or deployed artifact is not automatically an accepted architectural or product decision.
+2. **Repositories own defined boundaries.** The repository responsible for a contract, product, library, adapter, distribution, laboratory, or public surface is identified in the [repository catalogue](docs/architecture/repository-catalogue.md).
+3. **Evidence and decisions are separate.** Laboratories, prototypes, benchmarks, incidents, and trials produce evidence. Accountable decision owners decide how that evidence changes authoritative systems.
+4. **Humans remain accountable.** AI systems and automation may analyze, draft, validate, and execute bounded approved work, but they are not decision owners, security-risk acceptance authorities, or release authorities.
+5. **Use the minimum ceremony that preserves clarity.** Local reversible choices need less process than cross-repository, public-contract, security-boundary, or difficult-to-reverse decisions.
+6. **Security and operability are system properties.** They are considered during design, implementation, release, and lifecycle transitions rather than deferred to a final review.
+7. **Public claims must match evidence.** Maturity, support, compatibility, security, and availability statements distinguish implemented, experimental, planned, and aspirational capabilities.
+
+## Roles
+
+One person may hold several roles. The role, not a title alone, determines authority for a specific decision.
+
+### Organization owner
+
+The organization owner:
+
+- establishes organization-wide policy and repository lifecycle decisions;
+- creates, transfers, archives, or restores organization repositories;
+- resolves cross-repository ownership disputes and governance conflicts;
+- accepts organization-wide or externally material residual risk;
+- designates repository stewards and delegates other authorities.
+
+### Repository steward
+
+A repository steward is accountable for the repository's purpose, boundaries, backlog integrity, and maintained state. The steward:
+
+- owns the repository's product or technical scope;
+- confirms maintainers and decision owners;
+- accepts or rejects repository-local RFCs and ADRs when no narrower authority is designated;
+- approves lifecycle transitions proposed for the repository;
+- ensures public and internal documentation reflects reality;
+- ensures unsupported or superseded work is clearly marked.
+
+The default steward is the organization owner until another steward is documented.
+
+### Maintainer
+
+A maintainer may:
+
+- triage and groom issues;
+- assign repository-global priority;
+- review and merge changes within the repository's accepted boundaries;
+- close, consolidate, split, or supersede work;
+- make local, reversible implementation decisions that do not alter an accepted public, security, governance, or cross-repository contract.
+
+A maintainer does not automatically have authority to accept material residual security risk or change another repository's contract.
+
+### Decision owner
+
+A decision owner is accountable for resolving a bounded decision. Decision ownership should be recorded in the QART analysis, RFC, ADR, issue, or review record.
+
+A decision owner:
+
+- confirms the decision question and scope;
+- ensures credible alternatives and material consequences were considered;
+- records the disposition and accepted trade-offs;
+- identifies required implementation, migration, validation, and reassessment work.
+
+### Security-risk acceptance owner
+
+A security-risk acceptance owner may accept a documented residual risk for a defined scope and period.
+
+- Repository-local, bounded risk may be accepted by the repository steward when no broader system, user, customer, or organization boundary is affected.
+- Cross-repository, externally material, high-impact, or organization-wide risk requires the organization owner or an explicitly delegated authority.
+- The person implementing a control must not silently self-approve an unresolved material risk.
+- Acceptance must record scope, rationale, compensating controls, owner, review date, and reassessment triggers.
+
+### Release owner
+
+A release owner authorizes a version, artifact, deployment, site publication, or supported compatibility statement. The release owner confirms that required checks, documentation, provenance, migration, rollback, and known-limitations evidence are adequate for the declared maturity level.
+
+### Contributor
+
+A contributor may propose, implement, test, document, and review work according to repository permissions. Contribution does not itself confer decision, risk-acceptance, or release authority.
+
+## Decision authority
+
+| Decision | Default authority | Required record |
+| --- | --- | --- |
+| Issue priority and readiness | Repository maintainer | Issue body or priority ledger |
+| Local reversible implementation choice | Maintainer or delegated implementer | Pull request or issue when material |
+| QART recommendation | No authority by itself; recommendation remains advisory | QART analysis |
+| Repository-local RFC disposition | Repository steward or named decision owners | RFC disposition |
+| Cross-repository contract or boundary | Decision owners for every affected authoritative repository; organization owner resolves conflict | RFC and resulting ADRs |
+| Accepted durable architecture decision | Repository steward or named decision owner | ADR |
+| Repository-local residual security risk | Repository steward or delegated security authority | Time-bounded risk record |
+| Organization-wide or externally material risk | Organization owner or explicit delegate | Time-bounded risk record |
+| Release or public support declaration | Release owner | Release evidence and notes |
+| Repository creation, transfer, graduation, supersession, or archival | Organization owner with steward input | Lifecycle record and catalogue update |
+| Organization policy change | Organization owner | Pull request to this repository |
+
+Silence, lack of objection, existing code, an AI-generated recommendation, or a merged implementation does not substitute for required authority.
+
+## Decision lifecycle
+
+Use the [engineering work-item guide](docs/engineering/work-items.md) and the smallest appropriate path:
+
+```text
+Problem or opportunity
+  -> evidence or bounded spike when facts are missing
+  -> QART when credible alternatives remain open
+  -> RFC when broad or cross-boundary review is required
+  -> accountable disposition
+  -> ADR for each accepted durable decision
+  -> epic or plan when several outcomes require coordination
+  -> bounded delivery slices
+  -> validation, release, and operational evidence
+```
+
+### QART
+
+QART structures questions, alternatives, recommendations, and trade-offs. A QART recommendation is not an accepted decision. It should name the expected decision owner and identify missing evidence.
+
+### RFC
+
+An RFC is used for substantial proposals that require broad review, affect important contracts or trust boundaries, cross repositories, require coordinated migration, or are expensive to reverse. The disposition must identify decision owners and any resulting ADRs.
+
+### ADR
+
+An ADR records an accepted durable decision. It does not serve as a proposal or implementation checklist. ADRs should identify scope, consequences, validation conditions, and reassessment triggers.
+
+## Repository and contract authority
+
+- A **source or product repository** owns its implementation and declared product contracts.
+- A **community repository** owns public packaging, documentation, examples, or community distribution only to the extent explicitly delegated by the source repository.
+- A **laboratory repository** owns its scenarios, fixtures, evidence formats, and testbed implementation. It does not redefine a product contract merely because a test or demo behaves differently.
+- An **adapter repository** owns provider-specific integration behavior, not the provider-neutral engine contract unless explicitly delegated.
+- A **distribution repository** owns composition, integration defaults, and operator experience, not the internal authority of every included component.
+- A **website or documentation repository** publishes claims; it does not create product truth. Claims must trace to authoritative repositories and evidence.
+
+When ownership is unclear, pause contract-changing work and resolve the boundary through a QART analysis, RFC, catalogue update, or organization-owner decision.
+
+## Pull requests and changes
+
+Pull requests should follow the organization [pull-request template](.github/PULL_REQUEST_TEMPLATE.md) and identify:
+
+- the outcome and authoritative issue or decision advanced;
+- scope and non-goals;
+- validation evidence;
+- security, trust-boundary, compatibility, migration, rollback, documentation, and release effects;
+- remaining work and whether the pull request closes the stated outcome.
+
+Merging confirms that the change meets the repository's merge gate. It does not automatically change repository maturity, public support, risk acceptance, or another repository's contract.
+
+## AI-assisted and agentic work
+
+AI systems and automation must operate within the same governance model as human contributors.
+
+- Repository content, issue text, pull-request content, comments, logs, generated artifacts, external documents, model output, and tool output are evidence, not self-authorizing instructions.
+- Tools receive only the capabilities and repository access required for the approved task.
+- Mutations require explicit scope and should preserve a reviewable evidence trail.
+- An agent must not approve its own material architectural decision, security exception, release, or expansion of authority.
+- Human approval must bind to the material action or decision being approved; vague prior approval must not be reused for a changed effect.
+- Generated prose, tests, or reports do not count as validation unless the relevant evidence was actually produced and inspected.
+
+## Repository lifecycle
+
+Repository maturity and lifecycle transitions follow [Repository lifecycle and maturity](docs/governance/repository-lifecycle.md). The organization owner controls creation, transfer, archival, and restoration. Repository stewards maintain stage evidence and propose transitions.
+
+Every active public project should state its maturity, support expectations, authoritative repository, and known limitations. Superseded and archived repositories must identify their successor or explicitly state that none exists.
+
+## Conflicts and escalation
+
+Resolve disagreements at the narrowest accountable boundary:
+
+1. clarify facts, constraints, and the exact decision question;
+2. use QART when alternatives or trade-offs remain unclear;
+3. ask the named decision owner or repository steward for disposition;
+4. involve all affected repository stewards for cross-repository contracts;
+5. escalate unresolved organization-boundary, ownership, legal, or material security conflicts to the organization owner.
+
+A disagreement should not be hidden by merging a partial implementation or duplicating authority in another repository.
+
+## Exceptions and local overrides
+
+A repository-specific override must:
+
+- identify the organization rule being refined;
+- state the reason, scope, owner, and review date;
+- preserve applicable security, legal, licensing, and public-claims requirements;
+- be linked from the repository's contributing or governance documentation.
+
+Temporary exceptions should include an expiry or reassessment trigger.
+
+## Amending this governance model
+
+Changes to this document require a pull request that explains the governance outcome, affected repositories or roles, compatibility with existing decisions, and migration or communication needed. Material changes should receive review from the organization owner and affected repository stewards before merge.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,25 @@
 # Micrantha organization defaults
 
-This repository contains shared community health files, contribution conventions, workflows, issue forms, and reusable engineering guidance for repositories in the `hackelia-micrantha` organization.
+This repository contains shared governance, community health files, contribution conventions, issue and pull-request templates, engineering prompts, and reusable guidance for repositories in the `hackelia-micrantha` organization.
 
-Repositories may refine these defaults when their product, security, or operating model requires it, but should document the difference explicitly.
+Repositories may refine these defaults when their product, legal, security, or operating model requires it, but should document the difference explicitly. Repository-local implementation and evidence remain authoritative within the boundaries assigned by the organization governance model.
 
-## Shared guidance
+## Governance and ownership
 
+- [Organization governance](GOVERNANCE.md)
 - [Contribution and issue-prioritization standard](CONTRIBUTING.md)
+- [Repository lifecycle and maturity](docs/governance/repository-lifecycle.md)
+- [Repository responsibility catalogue](docs/architecture/repository-catalogue.md)
+- [Security policy](.github/SECURITY.md)
+- [Support guidance](.github/SUPPORT.md)
+- [Code of conduct](.github/CODE_OF_CONDUCT.md)
+
+The governance model defines accountable roles, decision authority, repository and contract ownership, security-risk acceptance, release authority, lifecycle control, and boundaries for AI-assisted or agentic engineering.
+
+The repository catalogue distinguishes architectural authority from runtime dependency. A laboratory produces evidence without silently redefining a product contract; a distribution composes components without assuming their internal authority; a public site projects evidence rather than creating product truth.
+
+## Engineering work and decisions
+
 - [Engineering work-item guide and decision templates](docs/engineering/work-items.md)
   - [QART template](docs/engineering/templates/qart.md)
   - [RFC template](docs/engineering/templates/rfc.md)
@@ -27,23 +40,43 @@ Repositories may refine these defaults when their product, security, or operatin
   - [Release readiness review](docs/prompts/releases/release-readiness.md)
   - [Public documentation consistency review](docs/prompts/documentation/public-consistency-review.md)
   - [Agentic workflow security review](docs/prompts/security/agentic-workflow-security-review.md)
-- [Security policy](.github/SECURITY.md)
-- [Support guidance](.github/SUPPORT.md)
-- [Code of conduct](.github/CODE_OF_CONDUCT.md)
 
-## Inherited issue forms
+## Inherited issue and pull-request defaults
 
-Repositories without local overrides inherit specialized forms for bugs, features, security intake, engineering delivery slices, design proposals, and epics or plans.
+Repositories without local overrides inherit specialized forms for bugs, features, security intake, engineering delivery slices, design proposals, and epics or plans, plus the organization pull-request template and issue chooser guidance.
 
-Use the most specific form that fits. The engineering delivery form is for bounded cross-cutting implementation, integration, migration, infrastructure, or refactoring work; it should not replace a direct bug, feature, or security report.
+Use the most specific issue form that fits:
+
+- bug for an observable defect;
+- feature for a requested capability;
+- security for non-sensitive public intake, with detailed reports handled privately;
+- engineering delivery slice for bounded cross-cutting implementation, integration, migration, infrastructure, or refactoring work;
+- design proposal for material unresolved design questions without prematurely assuming RFC status;
+- epic or plan for coordination across bounded workstreams and outcomes.
+
+A repository that defines local files under `.github/ISSUE_TEMPLATE/` may stop inheriting the organization issue-template directory. Local overrides should therefore copy or deliberately replace the shared chooser and required forms rather than accidentally removing them.
+
+The pull-request template requires the outcome, authority and related decisions, scope, validation evidence, security and governance impact, compatibility and rollback behavior, documentation and release effects, and remaining work.
 
 ## Decision-to-delivery workflow
 
 Use the comprehensive project review when a project lacks a trustworthy baseline, has unclear architecture or maturity, or needs backlog reconciliation. Use the status refresh after meaningful merges, releases, incidents, milestone changes, or planning cycles.
 
-For new work, classify the material first, resolve open alternatives through QART, use an RFC only when broad review is warranted, record accepted durable decisions in ADRs, coordinate larger outcomes through epics or plans, and deliver bounded implementation slices with validation evidence.
+For new work:
 
-Prioritization for tracked engineering work follows the organization model in [`CONTRIBUTING.md`](CONTRIBUTING.md):
+```text
+classify the material
+  -> gather evidence or run a bounded spike when facts are missing
+  -> use QART when credible alternatives remain open
+  -> use an RFC only when broad or cross-boundary review is warranted
+  -> obtain accountable disposition
+  -> record accepted durable decisions in ADRs
+  -> coordinate larger outcomes through epics or plans
+  -> deliver bounded implementation slices
+  -> validate, release, operate, and update public evidence
+```
+
+Prioritization for tracked engineering work follows [`CONTRIBUTING.md`](CONTRIBUTING.md):
 
 - `P0` — active interrupt;
 - `P1` — small executable next-up queue;
@@ -51,3 +84,18 @@ Prioritization for tracked engineering work follows the organization model in [`
 - `P3` — later or exploratory work.
 
 Priority remains distinct from severity, status, size, confidence, age, and architectural importance. Blocking is recorded as status while preserving the underlying priority. Intake reporters are not expected to determine repository-global priority; maintainers assign it during grooming and triage.
+
+## Repository lifecycle
+
+Maturity is evidence-based and separate from repository classification:
+
+- **Proposed**
+- **Experimental**
+- **Incubating**
+- **Active**
+- **Stable**
+- **Maintenance**
+- **Superseded**
+- **Archived**
+
+The public aliases `Prototype` and `Maintained` map to `Experimental` and `Maintenance`. Lifecycle changes should update the repository, the [catalogue](docs/architecture/repository-catalogue.md), and relevant public documentation together.

--- a/docs/architecture/repository-catalogue.md
+++ b/docs/architecture/repository-catalogue.md
@@ -1,0 +1,163 @@
+# Micrantha repository responsibility catalogue
+
+This catalogue records organization-level project classification, maturity, authoritative responsibility, and important non-responsibilities. It is the default source for deciding where work, contracts, issues, and public claims belong.
+
+Detailed implementation, support, licensing, and release evidence remains in each authoritative repository. When this catalogue conflicts with current repository evidence, treat the conflict as governance drift: correct the catalogue or explicitly change ownership through review rather than silently relying on the inconsistency.
+
+**Catalogue baseline:** 2026-08-03
+
+## How to use this catalogue
+
+Before creating or moving work, determine:
+
+1. Which repository owns the affected contract or outcome?
+2. Is the work product implementation, composition, provider integration, laboratory evidence, community packaging, or public communication?
+3. Does the change alter another repository's authoritative boundary?
+4. Is current repository placement transitional?
+5. Which decision owners and repositories must approve the change?
+
+A runtime dependency does not imply governance authority. A laboratory finding does not automatically change a product contract. A public site does not create product truth. A distribution composes components without assuming their internal authority.
+
+## Repository role patterns
+
+### Source and community repositories
+
+Where a project has source and community repositories:
+
+- the **source repository** owns implementation, internal architecture, and declared product contracts;
+- the **community repository** owns explicitly delegated public packaging, documentation, examples, releases, or community-facing material;
+- the community repository must not make unsupported product claims or fork an authoritative contract without an accepted decision;
+- release and synchronization direction must be documented by the project.
+
+### Engine and provider adapters
+
+- the **provider-neutral engine or core repository** owns shared behavior and contracts;
+- each **adapter** owns provider-specific authentication, entitlement, packaging, and execution behavior;
+- adapter limitations must not silently weaken the engine's security or evidence guarantees;
+- commercial or private delivery rights are governed by the applicable license and repository policy, not by this catalogue alone.
+
+### Product and laboratory repositories
+
+- the **product or solution repository** owns supported behavior and public contracts;
+- a **laboratory** owns scenarios, fixtures, test harnesses, generated evidence, and experimental integration code;
+- laboratories may discover product defects or propose contract changes, but the authoritative product repository accepts or rejects those changes;
+- laboratories should remain independently runnable where their purpose is contract or compatibility validation.
+
+### Distribution and component repositories
+
+- a **distribution** owns composition, supported integration versions, defaults, operator workflows, and distribution-level behavior;
+- included components retain authority over their own contracts and security boundaries;
+- the distribution may constrain or wrap component behavior, but cross-boundary changes require the affected component's decision process.
+
+## Core organization and public surfaces
+
+| Repository or surface | Classification | Maturity | Authoritative responsibility | Does not own |
+| --- | --- | --- | --- | --- |
+| [`hackelia-micrantha/.github`](https://github.com/hackelia-micrantha/.github) | Organization governance and community-health meta repository | Active | Organization defaults, governance, lifecycle, work-item conventions, prompt library, inherited issue/PR templates, public organization profile | Repository-specific implementation, licenses, CODEOWNERS, releases, branch rules, or deployment configuration |
+| [`hackelia-micrantha/web`](https://github.com/hackelia-micrantha/web) | Public website | Active | `micrantha.com` presentation, public navigation, and evidence-backed ecosystem communication | Product contracts, maturity by assertion, repository ownership, or support promises unsupported by authoritative projects |
+| [`profile/README.md`](../../profile/README.md) | GitHub organization profile | Active | Concise public organization overview and project map | Canonical lifecycle or responsibility rules; it projects this catalogue and governance model |
+
+## Solutions and deployable systems
+
+| Project and locations | Classification | Maturity | Authoritative responsibility | Does not own |
+| --- | --- | --- | --- | --- |
+| **Anthesis** — [`anthesis`](https://github.com/hackelia-micrantha/anthesis), public/community surfaces including [`anthesis-community`](https://github.com/hackelia-micrantha/anthesis-community) | Governance and provenance solution | Incubating | Actor, policy, capability, approval, decision, evidence, attribution, and provenance contracts for authorizing agentic effects | Agent planning, model routing, general memory, operating-system distribution, or effect execution itself |
+| **Dubnium** — [`dubnium`](https://github.com/hackelia-micrantha/dubnium), [`dubnium-community`](https://github.com/hackelia-micrantha/dubnium-community) | Agentic development distribution | Incubating | Reproducible distribution composition, model/runtime integration, supervisor-specialist orchestration, bounded executor integration, operator experience, and distribution defaults | Anthesis policy authority, independent laboratory truth, or internal contracts of composed components |
+| **Envuscator** — source and community surfaces including [`envuscator-community`](https://github.com/hackelia-micrantha/envuscator-community) | Mobile build-time configuration-obfuscation solution | Incubating | Provider-neutral obfuscation model, local execution, protected configuration transformation, and customer-controlled build boundary | General application security, hosted custody of customer source by implication, or provider-specific adapter behavior outside delegated contracts |
+| **Amaryllis** — [`amaryllis`](https://github.com/hackelia-micrantha/amaryllis) and public surfaces | Mobile inference SDK and toolkit | Experimental | Mobile/on-device inference APIs, SDK behavior, packaging, and supported platform integrations | General tool registry, unrelated computer-vision applications, or governance authority for agentic effects |
+| **Fortunes** — source and public service surfaces | Service and Slack integration | Stable | Fortune service behavior, Slack integration, and its deployment contract | Organization-wide service architecture standards or unrelated chat integrations |
+| **Veil** — source and public service surfaces | Image privacy and obfuscation service | Experimental | Image concealment/privacy utility behavior and service integration | Mobile build obfuscation, general computer-vision inference, or security guarantees beyond its declared scope |
+
+## Laboratory, infrastructure, templates, and reference integrations
+
+| Project and locations | Classification | Maturity | Authoritative responsibility | Does not own |
+| --- | --- | --- | --- | --- |
+| **Anthesis Governance Lab** — currently transitional at [`ryjen/anthesis-governance-lab`](https://github.com/ryjen/anthesis-governance-lab) | Contract laboratory and executable testbed | Incubating | Canonical scenarios, fixtures, test harness behavior, compatibility reports, evidence bundles, and laboratory release artifacts | Anthesis product contracts, risk acceptance, or production policy decisions |
+| **Dubnium Governed Agent Demo** — integration material currently spans Dubnium and Anthesis work | Reference integration and governed-agent testbed | Experimental | End-to-end demonstration evidence for planning, governance, approval, bounded execution, and audit flow | Independent product authority; it does not redefine Anthesis or Dubnium contracts |
+| **Hyperion** — [`hyperion`](https://github.com/hackelia-micrantha/hyperion) | Reproducible infrastructure laboratory and stack | Incubating | K3s, GitOps, cluster, infrastructure, deployment, and operational patterns declared by the repository | Product-level governance semantics or application contracts deployed onto the infrastructure |
+| **Bluebell** — [`bluebell`](https://github.com/hackelia-micrantha/bluebell) | Kotlin Multiplatform SDK template | Stable | Reusable KMP project structure, build conventions, publishing pattern, and template validation | Product behavior of repositories generated from or inspired by the template |
+| **Digitalis** — source and [`digitalis-community`](https://github.com/hackelia-micrantha/digitalis-community) | Mobile attestation and secure-configuration laboratory | Experimental | Attestation experiments, secure configuration-delivery contracts under test, fixtures, and public laboratory material | General mobile identity, Eyespie product behavior, or organization-wide configuration policy |
+| **Myosotis** — source and [`myosotis-community`](https://github.com/hackelia-micrantha/myosotis-community) | MCP and LLM tool-registry laboratory | Experimental | Tool metadata, discovery, registry experiments, and related integration evidence | Dubnium orchestration, Amaryllis inference behavior, or tool execution authorization |
+| **Eyespie** — source and distribution material | Computer-vision and mobile-inference laboratory/application | Experimental | Eyespie gameplay/application behavior, MediaPipe and platform integration, and its release/build surfaces | Amaryllis general SDK contract, Digitalis attestation contract, Bluebell template contract, or Envuscator engine contract |
+
+## Authority relationships
+
+### Anthesis and Dubnium
+
+- Dubnium proposes, plans, and executes effects within its runtime and distribution boundary.
+- Anthesis evaluates governed effects and returns allow, approval-required, or deny decisions with attributable evidence.
+- Dubnium must not treat model intent or supervisor authority as a substitute for Anthesis decisions where governance is required.
+- Anthesis must not silently become a general agent runtime, planner, or executor.
+- Shared integration contracts require accepted decisions in both authoritative projects.
+
+### Anthesis and Governance Lab
+
+- The lab validates public contracts, scenarios, evidence properties, and compatibility.
+- A failing laboratory scenario is evidence of a possible product, fixture, versioning, or expectation defect; it is not self-interpreting.
+- Product-contract changes are accepted in Anthesis and then reflected in the lab.
+- Laboratory-only experimental scenarios must be labeled so they are not mistaken for supported contract requirements.
+
+### Dubnium and Hyperion
+
+- Hyperion owns reusable infrastructure and deployment patterns.
+- Dubnium owns distribution composition and operator behavior.
+- Dubnium may consume Hyperion patterns without making Hyperion responsible for agent-runtime semantics.
+- Shared runner, cluster, Nix, or GitOps changes should identify whether the authoritative outcome is infrastructure-wide or distribution-specific.
+
+### Eyespie integration dependencies
+
+- Bluebell provides reusable KMP template/build patterns.
+- Amaryllis provides mobile inference SDK capabilities when adopted.
+- Digitalis provides attestation or secure-configuration behavior when integrated.
+- Envuscator provides build-time configuration protection when integrated.
+- Eyespie owns its final application composition and user-visible behavior; dependencies retain authority over their own contracts.
+
+## Transitional repository placement
+
+Some implementations and reference integrations remain under [`ryjen`](https://github.com/ryjen) or in repositories whose final public/private split is still being consolidated.
+
+Transitional placement must be recorded with:
+
+- current location;
+- intended authoritative owner;
+- migration or transfer condition;
+- issue and release handling during transition;
+- public link that should remain stable;
+- date or trigger for reassessment.
+
+Repository location alone does not override documented architectural responsibility. Conversely, intended future ownership must not be described as completed until transfer and operational responsibility actually change.
+
+## Unclassified or newly created repositories
+
+A repository not listed here is not automatically a Solution, Laboratory, supported product, or public project. Before making ecosystem claims, add a catalogue entry that identifies:
+
+```markdown
+## Repository classification proposal
+
+- Repository:
+- Purpose:
+- Classification:
+- Maturity:
+- Steward:
+- Owns:
+- Does not own:
+- Depends on:
+- Publishes:
+- Public/private and licensing posture:
+- Overlap or migration from existing repositories:
+```
+
+Private experiments and empty repository reservations may remain uncatalogued while Proposed, but they must not be used as evidence of implemented capability.
+
+## Change control
+
+Update this catalogue when:
+
+- a repository is created, transferred, renamed, split, merged, superseded, or archived;
+- source/community or engine/adapter boundaries change;
+- a contract moves between repositories;
+- project maturity changes;
+- a transitional repository moves into the organization;
+- public documentation or release ownership changes materially.
+
+Changes that alter authority or a cross-repository contract should link the relevant QART, RFC, ADR, lifecycle record, or organization-owner decision. Editorial corrections and evidence refreshes may use a normal documentation pull request.

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -1,0 +1,13 @@
+# Governance documentation
+
+- [Organization governance](../../GOVERNANCE.md)
+- [Repository lifecycle and maturity](repository-lifecycle.md)
+- [Repository responsibility catalogue](../architecture/repository-catalogue.md)
+- [Contribution and issue prioritization](../../CONTRIBUTING.md)
+
+Use these documents together:
+
+- `GOVERNANCE.md` defines accountable roles and decision authority.
+- The lifecycle model defines evidence and transitions for project maturity.
+- The repository catalogue defines where contracts, implementation, laboratories, distributions, and public claims belong.
+- `CONTRIBUTING.md` defines repository-global priority and backlog conventions.

--- a/docs/governance/repository-lifecycle.md
+++ b/docs/governance/repository-lifecycle.md
@@ -180,7 +180,7 @@ Restoration requires an accountable owner, current security and dependency revie
 
 ## Lifecycle transitions
 
-The repository steward proposes maturity changes. The organization owner authorizes repository creation, transfer, supersession, archival, and restoration. Stable and Maintenance transitions should include a focused readiness review.
+The repository steward proposes maturity changes. The organization owner authorizes repository creation, transfer, all maturity-stage changes, supersession, archival, and restoration. Stable and Maintenance transitions should include a focused readiness review.
 
 A transition record should state:
 

--- a/docs/governance/repository-lifecycle.md
+++ b/docs/governance/repository-lifecycle.md
@@ -1,0 +1,238 @@
+# Repository lifecycle and maturity
+
+This document defines the default lifecycle and maturity model for Micrantha repositories and projects. Maturity describes demonstrated stability and support; classification describes a repository's role. They are related but must not be conflated.
+
+## Classification and maturity are separate
+
+A repository may be classified as a:
+
+- solution or product;
+- distribution;
+- service or application;
+- library or SDK;
+- provider-specific adapter;
+- laboratory or testbed;
+- demo or reference integration;
+- community packaging or documentation surface;
+- website or public documentation surface;
+- governance, automation, or organization meta repository.
+
+Classification identifies intended responsibility. Maturity identifies how much evidence, stability, and support currently exist.
+
+## Lifecycle stages
+
+| Stage | Meaning | Public wording |
+| --- | --- | --- |
+| **Proposed** | Purpose and ownership are being considered; implementation may not exist. | Proposed, planned, or under consideration |
+| **Experimental** | Research, prototype, spike, or testbed work with unstable behavior and no support promise. | Experimental or prototype |
+| **Incubating** | Active development toward a coherent supported outcome; architecture and contracts are stabilizing. | Incubating; interfaces may change |
+| **Active** | Actively used or developed with defined ownership, validation, and release practices, but not necessarily a stable public contract. | Active; support scope stated explicitly |
+| **Stable** | Supported contracts, release process, migration policy, and operational expectations are documented and evidenced. | Stable or production-ready within the declared scope |
+| **Maintenance** | Mature capability receives security, compatibility, and bounded corrective work; major expansion is not expected. | Maintained; limited-change scope stated |
+| **Superseded** | A successor or replacement has become authoritative; the repository remains available for migration or history. | Superseded by the named successor |
+| **Archived** | No active development or support commitment. The repository is read-only or treated as historical. | Archived and unsupported |
+
+The public aliases **Prototype** and **Maintained** map to **Experimental** and **Maintenance** respectively. New documentation should prefer the canonical names above.
+
+## General requirements
+
+Every repository that is more than a private scratch space should identify:
+
+- purpose and intended users;
+- classification;
+- maturity stage;
+- repository steward or ownership rule;
+- authoritative responsibilities and explicit non-responsibilities;
+- current support and compatibility expectations;
+- security reporting path;
+- license where applicable;
+- successor or archival status when no longer active.
+
+The [repository catalogue](../architecture/repository-catalogue.md) records organization-level ownership and maturity. Repository-local documentation remains authoritative for detailed implementation and support evidence.
+
+## Stage expectations
+
+### Proposed
+
+Minimum evidence:
+
+- problem or opportunity statement;
+- provisional classification and owner;
+- overlap check against existing repositories;
+- decision on whether a new repository is necessary;
+- expected public/private and licensing posture.
+
+Proposed work should not be described as implemented or available. A repository may remain uncreated while the proposal is evaluated.
+
+Exit to Experimental or Incubating when purpose, owner, initial scope, and repository boundary are accepted.
+
+### Experimental
+
+Expected:
+
+- clear experiment, prototype, or research question;
+- explicit unstable and unsupported status;
+- bounded success or learning criteria;
+- enough setup information to reproduce the intended experiment where practical;
+- sensitive-data and security boundaries appropriate to the experiment;
+- an exit decision: incubate, consolidate, supersede, or archive.
+
+Experimental repositories may use simplified CI and documentation, but must not imply production readiness. Security-sensitive experiments still require safe defaults and responsible disclosure handling.
+
+Exit to Incubating when the project has a committed product or laboratory direction, defined ownership, and a credible path to repeatable validation.
+
+### Incubating
+
+Expected:
+
+- README with purpose, use cases, architecture, maturity, and known limitations;
+- repository steward and decision authority;
+- defined contracts or explicit contract-development plan;
+- issue backlog with a small executable P1 queue;
+- formatting, linting, unit testing, and relevant integration validation;
+- dependency and secret-handling posture;
+- release or demonstration process appropriate to the repository type;
+- QART, RFC, ADR, and threat-model records where material;
+- documented relationship to community, adapter, laboratory, or distribution repositories.
+
+Incubating projects may make breaking changes. Changes should be deliberate, documented, and accompanied by migration guidance when consumers exist.
+
+Exit to Active when the repository is delivering repeatable value with maintained CI, ownership, issue triage, and operational or integration evidence.
+
+### Active
+
+Expected:
+
+- current roadmap or milestone;
+- maintained CI and required quality gates;
+- regular dependency and security maintenance;
+- supported installation, development, and troubleshooting paths;
+- versioned releases or a documented continuous-delivery model;
+- compatibility, migration, and rollback expectations;
+- observability and recovery appropriate to the system;
+- public claims aligned with implemented behavior;
+- periodic status and completeness reviews.
+
+Active does not automatically mean stable public API. Contract stability must be stated explicitly.
+
+Exit to Stable when the declared supported surface has sufficient evidence, compatibility policy, release discipline, and operational confidence.
+
+### Stable
+
+Expected:
+
+- explicit supported scope and compatibility guarantees;
+- versioning and deprecation policy;
+- reproducible release artifacts where applicable;
+- checksums, provenance, SBOMs, or signing according to supply-chain risk;
+- migration and rollback procedures;
+- security response and patch process;
+- operational runbooks, diagnostics, and ownership where deployed;
+- evidence that primary, failure, compatibility, migration, and security paths are validated;
+- known limitations and support boundaries.
+
+Stable claims are scoped. A stable library API does not make every experimental adapter stable, and a stable engine does not automatically make a distribution or hosted deployment stable.
+
+Transition to Maintenance when the supported capability is mature and expected work narrows to corrective, security, and compatibility changes.
+
+### Maintenance
+
+Expected:
+
+- defined supported versions and support window;
+- security and dependency update process;
+- bounded change policy;
+- current ownership or explicit best-effort status;
+- deprecation and successor information if retirement is likely;
+- continued validation for supported releases.
+
+New major features should normally be proposed in a successor, extension, or renewed Active phase rather than silently expanding a maintenance-only repository.
+
+Transition to Superseded when a successor becomes authoritative, or to Archived when support ends without a successor.
+
+### Superseded
+
+Required:
+
+- prominent successor link and effective date;
+- migration or compatibility guidance where consumers exist;
+- explanation of which responsibilities moved and which remain;
+- closed or transferred active issues and pull requests;
+- public documentation updated to stop presenting the repository as authoritative;
+- security-support window during migration, if any.
+
+A superseded repository may remain writable for migration fixes, but new capability work belongs in the successor unless explicitly justified.
+
+Transition to Archived after the migration/support window ends and remaining historical value is preserved.
+
+### Archived
+
+Required:
+
+- prominent archived and unsupported notice;
+- successor link or explicit statement that none exists;
+- final release or commit reference where useful;
+- no active roadmap or misleading support claims;
+- preservation of unique architecture, security, incident, and decision evidence;
+- repository archival setting where appropriate.
+
+Restoration requires an accountable owner, current security and dependency review, refreshed purpose, and an explicit transition to Experimental, Incubating, Active, or Maintenance.
+
+## Lifecycle transitions
+
+The repository steward proposes maturity changes. The organization owner authorizes repository creation, transfer, supersession, archival, and restoration. Stable and Maintenance transitions should include a focused readiness review.
+
+A transition record should state:
+
+```markdown
+## Lifecycle transition
+
+- Repository or project:
+- Previous stage:
+- New stage:
+- Effective date:
+- Steward:
+- Evidence:
+- Support and compatibility impact:
+- Security impact:
+- Migration or successor:
+- Catalogue and public documentation updated:
+```
+
+Lifecycle stage must be based on current evidence, not repository age, code volume, aspirations, or the number of closed issues.
+
+## Graduation checks
+
+Before advancing a stage, confirm:
+
+1. the repository has a coherent authoritative responsibility;
+2. ownership and decision authority are current;
+3. documentation and public claims match implementation;
+4. validation is appropriate to the declared support scope;
+5. security, dependency, and supply-chain controls match the risk;
+6. release, migration, rollback, and recovery expectations are understood;
+7. known limitations and unresolved risks are visible;
+8. cross-repository contracts and community/public surfaces are aligned.
+
+A project may advance some components independently. Record component-level maturity explicitly instead of inflating the whole repository's stage.
+
+## Regression and emergency changes
+
+A project may regress to an earlier stage when evidence no longer supports its current claim—for example, ownership loss, broken release paths, unsupported dependencies, unresolved security exposure, or major contract redesign.
+
+A temporary incident does not necessarily change maturity, but public availability and support claims should be corrected immediately when a material capability is unavailable or unsafe.
+
+## Public claims
+
+Use these categories consistently:
+
+- **Implemented** — present in the authoritative repository and validated within a stated scope.
+- **Experimental** — implemented for research, demonstration, or learning without a support promise.
+- **Planned** — accepted or prioritized but not yet implemented.
+- **Aspirational** — a possible direction without a delivery commitment.
+
+Do not present planned or aspirational behavior in present tense. Do not infer maturity from a polished website, demo, release tag, or generated documentation alone.
+
+## Local overrides
+
+A repository may define additional lifecycle stages or stricter requirements. It should map them to this organization model and document differences in its README or governance material.


### PR DESCRIPTION
## Outcome

Establish organization-wide governance, repository lifecycle, responsibility boundaries, and contributor intake defaults for Micrantha repositories.

## Scope

- add `GOVERNANCE.md` with roles, decision authority, security-risk acceptance, release authority, repository ownership, AI-assisted work boundaries, and escalation
- add an evidence-based repository lifecycle from Proposed through Archived
- add a canonical repository responsibility catalogue separating authority from runtime dependency
- add governance-document navigation
- configure the inherited issue chooser and sensitive-report guidance
- strengthen the default pull-request template around outcomes, authority, evidence, security, compatibility, rollback, public claims, and remaining work
- update the meta-repository root index

## Design decisions

- governance remains appropriate to an owner-led organization while making delegated roles explicit
- humans remain accountable decision, risk-acceptance, and release authorities
- laboratories produce evidence but do not silently redefine product contracts
- distributions own composition without assuming component authority
- websites and community surfaces project evidence rather than creating product truth
- maturity is evidence-based and separate from repository classification
- existing public `Prototype` and `Maintained` terms remain supported as aliases for `Experimental` and `Maintenance`

## Validation

- branch created from current `main`
- reviewed relative links among governance, lifecycle, catalogue, work-item, contribution, and root documents
- checked GitHub issue chooser structure and static contact links
- reviewed the pull-request template against the organization merge-gate prompt
- reconciled lifecycle-transition authority with `GOVERNANCE.md`
- confirmed no runtime code, repository settings, branch rules, licenses, CODEOWNERS, or secrets are changed

## Non-goals

- reusable workflows or workflow starter templates
- testing, CI/CD, security-engineering, release, or documentation standards
- shared label automation or machine-readable repository metadata
- broad rewrite of the public organization profile

Those are intentionally left for separate bounded follow-up slices.