### PR TITLE
Add organization engineering standards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,8 @@ Use organization-standard labels when available:
 - `type:epic`
 - `type:spike`
 
+The complete shared naming and adoption rules are defined in the [label and work-item taxonomy](docs/standards/labels.md). Repositories should create only the subset they can maintain and must document any changed meanings.
+
 Issue-body priority text remains the durable explanation; labels support filtering and automation.
 
 ### Execution order

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Micrantha organization defaults
 
-This repository contains shared governance, community health files, contribution conventions, issue and pull-request templates, engineering prompts, and reusable guidance for repositories in the `hackelia-micrantha` organization.
+This repository contains shared governance, community health files, contribution conventions, issue and pull-request templates, engineering prompts, standards, and reusable guidance for repositories in the `hackelia-micrantha` organization.
 
 Repositories may refine these defaults when their product, legal, security, or operating model requires it, but should document the difference explicitly. Repository-local implementation and evidence remain authoritative within the boundaries assigned by the organization governance model.
 
@@ -17,6 +17,18 @@ Repositories may refine these defaults when their product, legal, security, or o
 The governance model defines accountable roles, decision authority, repository and contract ownership, security-risk acceptance, release authority, lifecycle control, and boundaries for AI-assisted or agentic engineering.
 
 The repository catalogue distinguishes architectural authority from runtime dependency. A laboratory produces evidence without silently redefining a product contract; a distribution composes components without assuming their internal authority; a public site projects evidence rather than creating product truth.
+
+## Engineering standards
+
+- [Standards overview](docs/standards/README.md)
+  - [Testing and validation](docs/standards/testing.md)
+  - [CI/CD](docs/standards/ci-cd.md)
+  - [Security engineering](docs/standards/security.md)
+  - [Releases and versioning](docs/standards/releases.md)
+  - [Documentation](docs/standards/documentation.md)
+  - [Labels and work-item taxonomy](docs/standards/labels.md)
+
+The standards define minimum outcomes according to repository classification, maturity, risk, supported surface, and deployment model. Repository-local standards may be stricter or may document a justified alternative control, but cannot silently weaken security, compatibility, release, support, or public-maturity claims.
 
 ## Engineering work and decisions
 

--- a/docs/standards/README.md
+++ b/docs/standards/README.md
@@ -1,0 +1,40 @@
+# Micrantha engineering standards
+
+These standards define organization-wide defaults for engineering evidence, security, delivery, documentation, and work-item taxonomy. They complement [`GOVERNANCE.md`](../../GOVERNANCE.md), the [repository lifecycle](../governance/repository-lifecycle.md), and repository-local requirements.
+
+## Standards
+
+- [Testing and validation](testing.md)
+- [CI/CD](ci-cd.md)
+- [Security engineering](security.md)
+- [Releases and versioning](releases.md)
+- [Documentation](documentation.md)
+- [Labels and work-item taxonomy](labels.md)
+
+## Application
+
+Apply requirements according to the repository's classification, maturity, risk, supported surface, and deployment model. A small experimental library does not need the same controls as a stable release pipeline or an authorization service, but it must state its limitations honestly.
+
+Repository-local standards may be stricter. A local exception should identify:
+
+- the organization default being changed;
+- why the default does not fit;
+- the replacement control or evidence;
+- affected security, compatibility, release, or support claims;
+- the accountable owner and review date.
+
+Exceptions do not authorize misleading maturity claims, weakened security boundaries without risk acceptance, or bypass of required release and validation gates.
+
+## Shared principles
+
+1. Validate outcomes and contracts, not only implementation details.
+2. Treat failure, migration, rollback, and security paths as first-class behavior.
+3. Keep CI least-privileged, deterministic, observable, and resistant to untrusted input.
+4. Do not describe planned, experimental, or partially integrated behavior as fully delivered.
+5. Preserve traceability from decisions and issues to code, validation, release evidence, and documentation.
+6. Prefer small, bounded, independently reviewable changes.
+7. Record limitations and residual risks instead of hiding them behind generic checklists.
+
+## Maturity relationship
+
+The [repository lifecycle](../governance/repository-lifecycle.md) defines when stronger evidence becomes necessary. Experimental repositories may use reduced ceremony, while Incubating, Active, Stable, and Maintenance repositories progressively require stronger validation, compatibility, release, operational, and support evidence.

--- a/docs/standards/ci-cd.md
+++ b/docs/standards/ci-cd.md
@@ -1,0 +1,121 @@
+# CI/CD standard
+
+CI/CD should provide trustworthy, least-privileged evidence about the exact revision being reviewed or released. A green aggregate status is insufficient when required work was skipped, ran against the wrong revision, or used an unsafe execution boundary.
+
+## Baseline outcomes
+
+Repositories beyond Experimental maturity should define automated checks appropriate to their stack and risk, normally including:
+
+- formatting or style validation;
+- linting and static analysis;
+- unit or component tests;
+- relevant contract and integration tests;
+- build or package validation;
+- dependency and supply-chain checks;
+- documentation or link validation where documentation is a supported surface.
+
+Native, platform, deployment, release, and end-to-end jobs should be added when those boundaries are part of the repository's declared outcome.
+
+## Required-check design
+
+- Use stable, meaningful job names suitable for branch protection.
+- Keep required checks conservative: unexpected paths or classifier failures should run the safer validation path.
+- A skipped required job must still produce an intentional, understandable result when GitHub branch rules depend on its name.
+- Do not weaken, rename, or remove a gate solely to merge a change.
+- Validate pull requests, pushes to protected branches, merge queues, and releases according to the repository's delivery model.
+- Ensure checks and release jobs operate on the intended commit, tag, or merge-queue revision.
+
+Change-aware gating is allowed when the classifier is tested, defaults safely, handles renames and generated files deliberately, and does not skip validation for unknown or shared-impact paths.
+
+## Workflow permissions
+
+Use least-privilege permissions at workflow and job scope. Default to read-only repository access and grant write capabilities only to the job that requires them.
+
+Separate build and validation from publication. Untrusted code must not gain access to:
+
+- repository or organization secrets;
+- writable tokens;
+- protected environments;
+- signing identities;
+- deployment credentials;
+- persistent internal infrastructure.
+
+Avoid `pull_request_target` for executing pull-request code. When it is required for metadata-only automation, do not check out or execute untrusted changes with privileged credentials.
+
+## Self-hosted runners
+
+Self-hosted runners are privileged infrastructure and require an explicit trust model.
+
+- Do not execute untrusted fork pull-request code on persistent self-hosted runners.
+- Prefer ephemeral, isolated runners for untrusted or high-risk workloads.
+- Separate runner groups by trust, repository, environment, and credential scope.
+- Minimize host mounts, device access, network reachability, and reusable state.
+- Clear workspaces, caches, credentials, and temporary artifacts between jobs.
+- Pin or attest runner images and bootstrap dependencies.
+- Monitor runner availability, queueing, disk pressure, and compromise indicators.
+
+Cost or speed does not justify exposing organization infrastructure to untrusted code.
+
+## Dependencies and actions
+
+- Pin third-party actions to immutable commit SHAs where practical, with a visible version comment.
+- Review action permissions, maintainer reputation, transitive behavior, and update strategy.
+- Use lockfiles and reproducible dependency installation.
+- Cache only trusted, integrity-checked material and scope caches to avoid cross-trust poisoning.
+- Record exceptions for floating action versions or network-fetched build inputs.
+
+## Reproducibility and command interface
+
+CI commands should be runnable locally or in an equivalent documented environment. Prefer a small, discoverable task interface over duplicated shell fragments.
+
+Micrantha repositories may use `mise` tasks as the standard entry point for formatting, linting, tests, builds, and release validation. Do not introduce `make` solely as an organizational requirement. Repository-local tools remain acceptable when commands and prerequisites are documented.
+
+Scripts should be bounded, tested where logic is material, and avoid becoming an undocumented second build system.
+
+## Concurrency and performance
+
+- Cancel superseded pull-request runs when safe.
+- Do not cancel release, deployment, merge-queue, or evidence-producing work when cancellation could leave ambiguous state.
+- Use caches and matrices deliberately; measure before adding complexity.
+- Keep fast deterministic checks early, but do not hide slow required validation indefinitely.
+- Split independent jobs while preserving clear required-gate semantics.
+
+## Artifacts and evidence
+
+Artifacts should have:
+
+- clear names and producing revision;
+- bounded retention appropriate to debugging, audit, or release needs;
+- protection from secret or personal-data leakage;
+- checksums or stronger integrity evidence when consumed downstream;
+- provenance and SBOMs according to release and supply-chain risk.
+
+Do not upload entire workspaces or verbose logs without reviewing their contents.
+
+## Deployment and environments
+
+- Use protected environments for sensitive publication or deployment.
+- Separate build identity from deployment identity.
+- Require explicit approval where the governance or risk model demands it.
+- Make deployment idempotent or safely resumable.
+- Define rollback, recovery, and partial-failure behavior.
+- Preserve who approved, what revision was deployed, which artifacts were used, and the resulting environment state.
+
+## Release pipelines
+
+Release automation should validate version identity, source revision, changelog or release notes, artifacts, checksums, signatures or provenance where required, and publication targets. A release job must not rebuild materially different artifacts after approval without recording that distinction.
+
+## Failure handling
+
+When CI fails:
+
+1. determine whether the product, test, workflow, runner, or external dependency failed;
+2. preserve relevant logs and artifact evidence without exposing secrets;
+3. repair the root cause rather than bypassing the gate;
+4. re-run against the current revision;
+5. identify flakiness or skipped coverage explicitly;
+6. confirm all required checks exist and completed before merge or release.
+
+## Local overrides
+
+Repository-specific workflows may differ, but they should document required checks, runner trust, publication authority, release identity, and any reduced validation. A local override cannot silently redefine a green check as evidence for a boundary that did not run.

--- a/docs/standards/documentation.md
+++ b/docs/standards/documentation.md
@@ -66,7 +66,7 @@ Require:
 - release verification and integrity instructions;
 - operational runbooks where deployed;
 - security response and patch expectations;
-- archived or superseded documentation preserved and linked.
+- archived or superseded documentation preserved and linked when it exists.
 
 ## Public claims
 

--- a/docs/standards/documentation.md
+++ b/docs/standards/documentation.md
@@ -1,0 +1,192 @@
+# Documentation standard
+
+Documentation is part of the supported product surface. It should help users, operators, contributors, reviewers, and future maintainers understand what exists, what is authoritative, how it behaves, and what remains uncertain.
+
+## Core requirements
+
+Every non-scratch repository should document the applicable subset of:
+
+- purpose, intended users, and supported use cases;
+- classification and maturity;
+- authoritative responsibilities and explicit non-responsibilities;
+- installation, setup, and first supported use;
+- architecture, components, contracts, state, and trust boundaries;
+- configuration and environment requirements;
+- development, testing, and CI commands;
+- security model and reporting path;
+- deployment, operation, observability, recovery, and troubleshooting;
+- versioning, release, migration, compatibility, and support policy;
+- known limitations, experimental areas, and planned work;
+- contributing and decision-making process;
+- license and ownership where applicable.
+
+Keep the README useful as an entry point. Move detailed material into focused documents rather than creating an unbounded README.
+
+## Documentation by maturity
+
+### Experimental
+
+Minimum:
+
+- question or purpose;
+- unsupported and unstable status;
+- setup or reproduction path where practical;
+- success or learning criteria;
+- sensitive-data and safety limitations.
+
+### Incubating
+
+Add:
+
+- architecture and use cases;
+- current integration boundaries;
+- development and validation instructions;
+- known limitations and breaking-change posture;
+- QART, RFC, ADR, or threat-model links where material;
+- relationship to community, adapter, distribution, or laboratory repositories.
+
+### Active
+
+Add and maintain:
+
+- supported installation and operation;
+- compatibility and migration guidance;
+- troubleshooting and ownership;
+- current release model and roadmap;
+- public contracts and failure behavior;
+- periodic reconciliation between documentation and implementation.
+
+### Stable and Maintenance
+
+Require:
+
+- explicit supported scope and versions;
+- versioning and deprecation rules;
+- migration and rollback procedures;
+- release verification and integrity instructions;
+- operational runbooks where deployed;
+- security response and patch expectations;
+- archived or superseded documentation preserved and linked.
+
+## Public claims
+
+Classify claims consistently:
+
+- **Implemented** — present in the authoritative repository and validated within the stated scope.
+- **Experimental** — implemented for research or demonstration without a support promise.
+- **Planned** — accepted or prioritized but not implemented.
+- **Aspirational** — possible direction without a delivery commitment.
+
+Do not write planned or aspirational behavior in present tense. Do not infer production readiness from a polished demo, website, diagram, release tag, or generated document.
+
+Public websites, organization profiles, community repositories, one-pagers, and presentations should project authoritative repository evidence. They do not independently create product truth.
+
+## Architecture documentation
+
+Architecture documentation should identify:
+
+- system context and actors;
+- repository and component responsibilities;
+- data and control flow;
+- state ownership and consistency;
+- public and internal contracts;
+- trust, authorization, approval, and execution boundaries;
+- dependency direction;
+- failure, retry, recovery, and rollback behavior;
+- deployment and operational ownership;
+- material alternatives and accepted decisions.
+
+Use diagrams when they improve understanding, but accompany them with text that explains authority and boundaries. A dependency arrow does not imply ownership.
+
+## Decision records
+
+Use the organization work-item and decision guidance:
+
+- QART for unresolved alternatives and trade-offs;
+- RFC for substantial proposals requiring broad review;
+- ADR for accepted durable decisions;
+- issues and epics for delivery outcomes and sequencing.
+
+Link decisions to implementation and follow-up. Do not rewrite history to make an earlier proposal appear inevitable; preserve supersession and changed assumptions.
+
+## User and operator guidance
+
+User documentation should include supported prerequisites, common path, errors, limitations, compatibility, and recovery. Operator documentation should include configuration, health, metrics, logs, alerts, failure modes, backup or recovery, upgrades, rollback, and escalation.
+
+Troubleshooting guidance should explain how to distinguish likely causes and collect safe diagnostics. Do not instruct users to publish secrets or sensitive data.
+
+## Security documentation
+
+Document the applicable:
+
+- assets and trust boundaries;
+- authentication, authorization, delegation, and approvals;
+- sensitive-data and secret handling;
+- threat assumptions and residual risks;
+- secure defaults and failure posture;
+- evidence, logging, retention, and privacy;
+- private vulnerability-reporting path.
+
+Public security documentation should provide useful boundaries without disclosing active secrets or unnecessary exploit detail.
+
+## Examples and generated content
+
+- Keep examples executable or clearly illustrative.
+- Pin or identify versions when behavior changes materially.
+- Do not use real credentials or personal data.
+- Validate generated commands, configuration, schemas, and API examples.
+- Mark placeholders visibly.
+- Treat AI-generated documentation as a draft requiring evidence-backed human review.
+
+## Docs-as-code validation
+
+Where documentation is a supported surface, automate applicable:
+
+- Markdown formatting and linting;
+- internal and external link checks;
+- code, configuration, and schema examples;
+- diagram syntax;
+- API or CLI reference generation drift;
+- spelling or terminology checks;
+- public-claim consistency and stale-version detection.
+
+Do not block critical fixes on unreliable external-link checks without a documented fallback, but do not ignore persistent documentation failures.
+
+## Change requirements
+
+A change should update documentation when it affects:
+
+- user-visible behavior;
+- public or cross-repository contracts;
+- configuration, prerequisites, or defaults;
+- security, privacy, or trust boundaries;
+- migration, compatibility, release, or support;
+- deployment, observability, recovery, or troubleshooting;
+- repository responsibility or maturity;
+- known limitations or public claims.
+
+Documentation follow-up may be separate only when the existing material remains safe and accurate and the follow-up has an owner and bounded deadline.
+
+## Supersession and archival
+
+When a document, decision, repository, or capability is superseded:
+
+- preserve the historical material;
+- add a prominent successor link and effective date;
+- stop presenting the old source as authoritative;
+- update inbound indexes and public surfaces;
+- retain unique security, architecture, incident, and migration evidence.
+
+## Review checklist
+
+A documentation review should verify:
+
+1. authority and intended audience are clear;
+2. current behavior and maturity are represented accurately;
+3. instructions are complete enough for the declared use case;
+4. security-sensitive material is safe;
+5. compatibility, migration, and limitations are visible;
+6. links and examples resolve;
+7. duplicate sources of truth are avoided;
+8. planned and implemented claims are distinguished;
+9. ownership and update triggers are understood.

--- a/docs/standards/labels.md
+++ b/docs/standards/labels.md
@@ -1,0 +1,177 @@
+# Label and work-item taxonomy
+
+Labels support filtering, triage, reporting, and bounded automation. They do not replace the durable rationale, outcome, dependencies, acceptance criteria, ownership, or evidence in an issue or pull request.
+
+Repositories should use the smallest useful subset of this taxonomy. Do not create labels that remain ambiguous, duplicate another dimension, or require constant manual maintenance without decision value.
+
+## Naming convention
+
+Use `dimension:value` for organization-standard dimensions:
+
+```text
+priority:P1
+status:blocked
+type:epic
+area:ci
+maturity:incubating
+```
+
+Use lowercase values and hyphens for multiword terms. Preserve established ecosystem terms and product names where case matters only in prose, not labels.
+
+## Priority
+
+Priority labels are mutually exclusive:
+
+- `priority:P0` — active interrupt;
+- `priority:P1` — small executable next-up queue;
+- `priority:P2` — planned work;
+- `priority:P3` — later, exploratory, duplicated, or uncommitted work.
+
+Priority follows [`CONTRIBUTING.md`](../../CONTRIBUTING.md). `Blocked` is not a priority. The issue body should record the repository-global rationale because labels alone do not explain why capacity should be allocated.
+
+Umbrella epics may have priority for coordination, but the next executable slice must be identified separately.
+
+## Status
+
+Status labels describe workflow state and may coexist when meanings are not contradictory:
+
+- `status:needs-grooming` — outcome, scope, dependencies, or acceptance criteria are incomplete;
+- `status:needs-evidence` — a decision or implementation claim lacks required evidence;
+- `status:needs-decision` — material alternatives or authority remain unresolved;
+- `status:blocked` — cannot proceed because a named dependency or condition is unresolved;
+- `status:ready` — sufficiently understood and unblocked for its next action;
+- `status:in-progress` — actively being worked;
+- `status:needs-review` — awaiting accountable review;
+- `status:needs-validation` — implementation exists but required evidence is incomplete;
+- `status:deferred` — valid but intentionally not scheduled;
+- `status:superseded` — replaced by a named issue, decision, PR, or repository.
+
+Avoid using labels for terminal GitHub states already represented by open, closed, merged, or draft unless reporting requires it.
+
+`status:ready` and `status:blocked` are normally mutually exclusive. Remove stale state labels when conditions change.
+
+## Work-item type
+
+Use one primary type where possible:
+
+- `type:bug` — incorrect observable behavior;
+- `type:feature` — new user, operator, or system capability;
+- `type:delivery` — bounded cross-cutting implementation, integration, migration, infrastructure, or refactoring outcome;
+- `type:epic` — coordinates a larger outcome across bounded child work;
+- `type:spike` — reduces uncertainty and produces evidence;
+- `type:design` — explores or proposes architecture or system behavior;
+- `type:qart` — resolves one bounded decision through alternatives and trade-offs;
+- `type:rfc` — substantial proposal requiring broad review;
+- `type:adr` — accepted durable decision record;
+- `type:security` — security vulnerability, hardening, threat analysis, or control work;
+- `type:documentation` — documentation is the primary outcome;
+- `type:maintenance` — dependency, compatibility, cleanup, or routine corrective work;
+- `type:release` — release preparation, publication, or support action.
+
+Security may also be represented as an area or impact on another primary type. Use `type:security` when security work is the main outcome rather than automatically adding it to every security-relevant change.
+
+## Area
+
+Area labels identify ownership or technical surface. They are repository-specific, but common values include:
+
+- `area:architecture`
+- `area:ci`
+- `area:release`
+- `area:security`
+- `area:documentation`
+- `area:dependencies`
+- `area:infrastructure`
+- `area:mobile`
+- `area:android`
+- `area:ios`
+- `area:web`
+- `area:api`
+- `area:data`
+- `area:observability`
+- `area:governance`
+
+Prefer a few meaningful ownership or contract boundaries over one label per directory. Multiple area labels are acceptable for genuinely cross-cutting work.
+
+## Maturity
+
+Maturity labels follow the [repository lifecycle](../governance/repository-lifecycle.md):
+
+- `maturity:proposed`
+- `maturity:experimental`
+- `maturity:incubating`
+- `maturity:active`
+- `maturity:stable`
+- `maturity:maintenance`
+- `maturity:superseded`
+- `maturity:archived`
+
+Use maturity labels primarily for repositories, components, milestones, or dedicated lifecycle issues. Do not add a maturity label to every implementation issue unless it materially affects triage.
+
+## Impact and risk
+
+Severity, user impact, confidence, effort, and change risk are separate from priority. Repositories may add dimensions such as:
+
+- `severity:critical`, `severity:high`, `severity:medium`, `severity:low`;
+- `risk:high`, `risk:medium`, `risk:low`;
+- `confidence:low`;
+- `breaking-change`;
+- `security-sensitive`;
+- `release-blocker`.
+
+Define these locally before using them. Do not infer `priority:P0` from `severity:critical` without assessing current exposure, urgency, and repository-global capacity.
+
+## Dependencies and relationships
+
+Use GitHub issue and pull-request links for exact relationships:
+
+- blocked by;
+- blocks or unlocks;
+- parent epic;
+- duplicate;
+- supersedes or superseded by;
+- related RFC, ADR, QART, release, or repository.
+
+Labels such as `blocked` or `duplicate` may support filters, but the linked source remains authoritative.
+
+## Pull-request labels
+
+Pull requests may reuse type, area, risk, and release labels. Avoid assigning issue priority automatically to a PR; a PR advances an outcome but does not become urgent merely because it is open.
+
+Useful PR-only labels may include:
+
+- `breaking-change`;
+- `needs-release-note`;
+- `dependencies`;
+- `automated`;
+- `do-not-merge` for an explicit temporary gate with a written reason.
+
+Do not use `do-not-merge` as a substitute for draft state, failing required checks, or unresolved review findings.
+
+## Automation rules
+
+Automation may apply or remove labels when the rule is deterministic and reversible. It should not:
+
+- assign priority without an accountable rationale;
+- accept security risk;
+- infer decision acceptance from merged code;
+- mark an epic complete solely because known child issues closed;
+- remove a human-applied governance or release hold without authority;
+- create labels that do not exist consistently across intended repositories.
+
+When inherited issue templates reference labels, those labels must exist in the consuming repository. Prefer templates without mandatory labels unless organization automation ensures label availability.
+
+## Repository adoption
+
+When adopting the taxonomy:
+
+1. inventory existing labels and usage;
+2. map meanings before renaming;
+3. preserve issue history and saved-filter needs;
+4. create only the subset the repository will maintain;
+5. update issue forms, templates, automation, and documentation together;
+6. remove obsolete labels after open work is migrated;
+7. document local additions or changed meanings.
+
+## Review cadence
+
+Review the taxonomy when labels become unused, contradictory, overly numerous, or disconnected from planning and reporting. A smaller accurate taxonomy is better than comprehensive but unreliable metadata.

--- a/docs/standards/releases.md
+++ b/docs/standards/releases.md
@@ -1,0 +1,143 @@
+# Release and versioning standard
+
+A release is an accountable statement that a specific source revision produced identified artifacts or deployment state with declared support, compatibility, and security properties.
+
+## Release authority
+
+Repository release authority follows [`GOVERNANCE.md`](../../GOVERNANCE.md). The release owner confirms that required evidence exists for the exact revision and artifacts being published. Automation may perform publication but does not independently authorize the release.
+
+## Versioning
+
+Use Semantic Versioning for public libraries, APIs, CLIs, packages, and contracts unless the repository documents a better domain-specific scheme.
+
+- **Major** — incompatible change to the declared supported contract.
+- **Minor** — backward-compatible capability addition.
+- **Patch** — backward-compatible correction or security fix.
+
+Pre-1.0 versions may evolve quickly, but breaking changes must still be intentional and documented. A `0.x` version is not permission to conceal compatibility impact.
+
+Applications, continuously delivered services, operating-system configurations, datasets, websites, or model artifacts may use date, build, channel, or revision-based identities. The scheme must remain monotonic or otherwise unambiguous and traceable to source.
+
+## Release channels
+
+Repositories may define:
+
+- development or nightly;
+- alpha;
+- beta;
+- release candidate;
+- stable;
+- maintenance or long-term support.
+
+Each channel should state its stability, support, compatibility, and upgrade expectations. Promotion between channels should reuse or identify the same artifacts where practical rather than silently rebuilding different content.
+
+## Required release record
+
+A release should identify:
+
+- version or immutable release identity;
+- source commit and tag;
+- release date and owner;
+- supported platforms, configurations, and consumers;
+- changes, fixes, security impact, and known limitations;
+- compatibility, migration, upgrade, and rollback implications;
+- artifacts and checksums;
+- provenance, SBOM, and signatures when required;
+- validation evidence and unresolved exceptions;
+- deprecations and support window.
+
+Release notes should describe externally meaningful outcomes rather than reproduce the commit log.
+
+## Tags and branches
+
+- Protect or restrict release tags according to repository risk.
+- Use annotated or signed tags when authenticity requirements justify them.
+- Do not move or overwrite published stable tags.
+- Record hotfix and maintenance branch policy where supported versions diverge.
+- Treat a tag as a reference, not proof that artifacts were correctly built or published.
+
+## Artifacts
+
+Release artifacts should be:
+
+- built from the intended source revision;
+- reproducible or at least provenance-linked;
+- named with version, platform, architecture, and format where applicable;
+- validated after packaging, not only before it;
+- accompanied by checksums and stronger integrity evidence according to risk;
+- free of secrets, credentials, development-only material, and unintended personal data;
+- retained or mirrored according to support commitments.
+
+For mobile, native, container, Nix, package-registry, and provider-adapter releases, validate installation or consumption through the supported channel.
+
+## Supply-chain evidence
+
+Use the level appropriate to the artifact and maturity:
+
+- checksums for downloadable assets;
+- SBOMs for distributable software and container images;
+- provenance or build attestations for higher-risk release pipelines;
+- signing for artifacts, tags, packages, or metadata where identity and tamper resistance are material;
+- immutable digests for deployed images and generated release evidence.
+
+Document the verification procedure. Evidence users cannot verify is incomplete.
+
+## Compatibility and migration
+
+Before release, identify:
+
+- public API, schema, command, configuration, data, file-format, policy, and deployment changes;
+- backward and forward compatibility;
+- mixed-version behavior;
+- required data or configuration migration;
+- deprecation period and successor;
+- rollback limits and irreversible changes.
+
+Breaking changes require an accepted decision or explicit release authority appropriate to their scope. Update consumers, community surfaces, and integration testbeds in dependency order.
+
+## Security releases
+
+Security fixes should minimize disclosure risk while preserving enough information for users to assess urgency and affected versions.
+
+- Coordinate patch, credential rotation, publication, and disclosure.
+- Avoid publishing exploit details before users have a reasonable remediation path.
+- Identify affected and fixed versions accurately.
+- Do not misclassify an unverified mitigation as a complete fix.
+- Backport according to the declared support policy and risk.
+
+## Release readiness
+
+Use the organization [release-readiness prompt](../prompts/releases/release-readiness.md) or an equivalent gate for material releases. At minimum confirm:
+
+- version identity is correct;
+- required checks ran on the release revision;
+- artifacts were packaged and consumed successfully;
+- security and dependency findings are dispositioned;
+- compatibility, migration, rollback, and known limitations are documented;
+- public documentation matches the released capability;
+- publication credentials and targets are scoped correctly.
+
+## Publication authority across repositories
+
+The authoritative implementation repository owns product or contract release identity. Community, website, adapter, and distribution repositories publish their own packaging or integration releases without redefining upstream component maturity.
+
+When GitHub and GitLab both participate, document which repository or registry is authoritative for source, tags, packages, release notes, and mirrors. Mirrors must not create conflicting release histories.
+
+## Rollback, yanking, and revocation
+
+Define how to:
+
+- stop or pause publication;
+- yank or deprecate a package without erasing history;
+- revoke a signing identity or compromised artifact;
+- roll back a deployment or configuration;
+- communicate a broken or unsafe release;
+- preserve evidence for incident review.
+
+Do not delete published evidence merely to make a failed release disappear.
+
+## Deprecation and end of support
+
+Deprecation should identify the affected surface, replacement, migration path, warning period, final supported version, and end-of-support date where applicable.
+
+A repository moving to Superseded, Maintenance, or Archived must update release channels and public documentation according to the [repository lifecycle](../governance/repository-lifecycle.md).

--- a/docs/standards/security.md
+++ b/docs/standards/security.md
@@ -1,0 +1,152 @@
+# Security engineering standard
+
+This standard defines engineering controls for Micrantha repositories. It complements the vulnerability-reporting instructions in `.github/SECURITY.md`; it does not replace them.
+
+Security is a system property created by architecture, implementation, delivery, operations, and governance. A security label or scan does not prove that a trust boundary is correct.
+
+## Security ownership
+
+Each repository should identify the owner of material security decisions, residual-risk acceptance, incident response, and release blocking. Organization-wide authority follows [`GOVERNANCE.md`](../../GOVERNANCE.md).
+
+Risk acceptance must be explicit, scoped, time-bounded where appropriate, and attributable to a human decision owner. An automated tool, model, laboratory, or pull-request author cannot accept its own residual risk.
+
+## Threat-model triggers
+
+Perform or refresh focused threat analysis when a change materially affects:
+
+- authentication, authorization, delegation, approval, or identity;
+- trust boundaries among users, services, agents, tools, runners, devices, or repositories;
+- secrets, keys, tokens, signing identities, or sensitive configuration;
+- personal, regulated, customer, or security-sensitive data;
+- executable content, plugins, package installation, build systems, or supply-chain inputs;
+- network exposure, tenancy, isolation, or resource limits;
+- policy enforcement, audit evidence, provenance, or bypass paths;
+- persistence, recovery, deletion, migration, or retention;
+- privileged mobile, infrastructure, or deployment capabilities.
+
+Use the smallest artifact that resolves the risk: issue analysis, QART slice, threat model, RFC, ADR, or focused security review.
+
+## Core requirements
+
+### Least privilege and authority
+
+- Grant only the capability, resource, scope, and lifetime required.
+- Separate proposal, authorization, execution, and evidence responsibilities where material.
+- Prevent confused-deputy behavior by binding requests to the initiating actor, intended resource, and approved parameters.
+- Make delegation explicit, bounded, revocable, and attributable.
+- Treat administrative, release, signing, and deployment authority as separate capabilities.
+
+### Secure defaults and failure posture
+
+- Default to denial or a safe non-effect state at authorization and verification boundaries.
+- Define fail-open, fail-closed, quarantine, retry, override, and recovery behavior explicitly.
+- Avoid silent fallback that weakens authentication, policy, integrity, or encryption.
+- Bound retries, resource consumption, and recursive or agentic execution.
+
+### Input and data handling
+
+- Treat repository content, prompts, logs, files, schemas, network responses, user data, and generated output as untrusted until validated for the consuming boundary.
+- Validate structure, type, size, encoding, path, origin, freshness, and authorization as applicable.
+- Prevent traversal, injection, unsafe deserialization, command construction, and unintended interpretation across language or protocol boundaries.
+- Minimize collection and retention of sensitive data.
+- Redact secrets and personal data from logs, evidence, errors, tests, and artifacts.
+
+### Secrets and cryptographic material
+
+- Do not commit secrets, private keys, production tokens, or sensitive credential material.
+- Use scoped secret stores and short-lived credentials where supported.
+- Separate development, CI, release, and production identities.
+- Rotate credentials after suspected exposure and preserve only non-sensitive incident evidence.
+- Document key ownership, rotation, revocation, recovery, and algorithm-agility expectations where cryptography is material.
+
+### Dependency and supply-chain controls
+
+- Use lockfiles or equivalent reproducible resolution.
+- Review new privileged, executable, native, build-time, and release dependencies more carefully than ordinary libraries.
+- Pin third-party CI actions and verify downloaded artifacts where practical.
+- Generate SBOM, provenance, checksums, or signatures according to release and supply-chain risk.
+- Define vulnerability triage, update, exception, and end-of-support handling.
+- Avoid executing install scripts or generated code with broader privileges than required.
+
+### Isolation and resource boundaries
+
+- Isolate untrusted workloads from persistent credentials, private networks, host devices, and reusable runner state.
+- Apply filesystem, process, network, device, tenant, and resource limits appropriate to the threat model.
+- Treat containers as a boundary aid, not proof of isolation.
+- Avoid running untrusted fork code on privileged or persistent self-hosted infrastructure.
+
+## Agentic and AI-assisted systems
+
+Agentic workflows require explicit control boundaries:
+
+1. **Actor** — who or what requested the action.
+2. **Proposal** — the exact intended effect and parameters.
+3. **Policy** — the rules and context used to evaluate it.
+4. **Approval** — accountable authorization where required.
+5. **Execution** — the bounded capability that performs the effect.
+6. **Evidence** — attributable records of inputs, decisions, approvals, execution, and result.
+7. **Recovery** — cancellation, rollback, containment, or remediation.
+
+Required properties should include, according to risk:
+
+- least-privilege tools and scoped credentials;
+- deterministic gates for material effects;
+- separation between generated instructions and trusted policy;
+- prompt-injection and untrusted-content resistance;
+- approval binding to the exact action or digest;
+- replay and stale-approval protection;
+- provenance and tamper-evident evidence;
+- bounded memory access and sensitive-context handling;
+- bypass detection and fail-closed behavior;
+- human override that is authenticated, attributable, and auditable.
+
+A supervisor/specialist pattern does not by itself provide authorization. The supervisor, memory system, policy authority, and executor must have separate, explicit responsibilities.
+
+## Logging, evidence, and privacy
+
+Security evidence should answer who requested, who approved, what was evaluated, what changed, when it occurred, and which code/configuration/policy versions were involved.
+
+Logs and evidence must not become a second secret store. Apply classification, access control, redaction, retention, integrity protection, and deletion rules. Record hashes or references instead of sensitive payloads when sufficient.
+
+## Security validation
+
+Validation should test protected invariants and denial behavior, including applicable:
+
+- unauthorized and cross-tenant access;
+- malformed, oversized, stale, replayed, or tampered input;
+- approval mismatch and bypass attempts;
+- secret and sensitive-data leakage;
+- dependency, runner, and build-boundary failures;
+- degraded dependencies and partial execution;
+- rollback, revocation, and incident containment.
+
+Security tools support review but do not replace architecture analysis, manual inspection, or boundary-level tests.
+
+## Vulnerability and incident handling
+
+- Follow the repository or organization private reporting path.
+- Do not place exploit details, secrets, or affected-user data in public issues.
+- Contain active exposure before broad cleanup.
+- Preserve enough evidence for diagnosis without spreading sensitive material.
+- Track remediation, credential rotation, release impact, disclosure, and prevention work separately when needed.
+- Convert incident learning into tests, controls, documentation, or decisions.
+
+## Security exceptions
+
+An exception should record:
+
+```markdown
+## Security exception
+
+- Control or requirement:
+- Scope and affected assets:
+- Rationale:
+- Compensating controls:
+- Residual risk:
+- Risk owner:
+- Approval date:
+- Expiry or review date:
+- Removal plan:
+```
+
+Expired exceptions are unresolved findings. They must not silently become permanent architecture.

--- a/docs/standards/testing.md
+++ b/docs/standards/testing.md
@@ -1,0 +1,108 @@
+# Testing and validation standard
+
+Testing exists to provide evidence that a declared outcome, contract, or safety property is true. Test count and coverage percentages are supporting signals, not substitutes for risk-based validation.
+
+## Required validation model
+
+For each material change, identify:
+
+- the behavior or property being validated;
+- the authoritative contract or acceptance criterion;
+- the relevant primary, failure, edge, migration, rollback, and security paths;
+- the smallest test layer that provides trustworthy evidence;
+- any behavior that remains unverified and why.
+
+Do not add every test type mechanically. Use the combination required by the risk and integration boundary.
+
+## Test layers
+
+| Layer | Purpose | Typical evidence |
+| --- | --- | --- |
+| Unit or component | Local logic, state transitions, parsing, policy, and error handling | Fast deterministic tests isolated from external systems |
+| Contract | Public API, schema, command, event, file format, exit code, or provider boundary | Producer/consumer compatibility and stable error semantics |
+| Integration | Real interaction among owned components or infrastructure | Database, filesystem, network, runner, package, or service behavior |
+| End-to-end | Supported user or operator outcome across the deployed path | Install, execute, approve, release, recover, or migrate workflow |
+| Security and negative path | Authorization, validation, isolation, abuse resistance, and safe failure | Denial, redaction, least privilege, replay resistance, boundary enforcement |
+| Migration and compatibility | Existing consumers, data, configuration, and mixed versions | Upgrade, downgrade where supported, rollback, and deprecation behavior |
+| Performance and capacity | Declared latency, throughput, resource, or scale limits | Reproducible benchmark with environment and threshold |
+| Operational exercise | Detection, diagnosis, recovery, and ownership | Alert, runbook, failure injection, restore, or incident simulation |
+
+## Expectations by change
+
+### Bug fixes
+
+A bug fix should include a regression test at the lowest trustworthy layer. When the defect crossed a boundary or escaped existing validation, add or strengthen the boundary-level test that should have detected it.
+
+### New capabilities
+
+Validate the primary outcome, relevant failure behavior, authorization and data boundaries, compatibility commitments, and an integrated supported path. Merged local slices do not prove capability completeness by themselves.
+
+### Refactoring
+
+Preserve observable behavior with focused tests. Add characterization tests when behavior is poorly specified, but do not freeze accidental defects or internal structure without justification.
+
+### Security changes
+
+Test the protected invariant and denial behavior, not only the successful path. Evidence should show that unauthorized, malformed, stale, replayed, or untrusted input cannot cross the affected boundary where those cases are material.
+
+### Releases and migrations
+
+Validate artifact installation or consumption, version identity, upgrade behavior, compatibility claims, release metadata, and rollback or recovery where promised.
+
+## Determinism and isolation
+
+Tests should be reproducible and independent of execution order. Control time, randomness, external services, environment, locale, filesystem state, and network access where they affect results.
+
+A test may intentionally exercise real external infrastructure when that boundary is the subject of validation. Mark such tests clearly, make prerequisites explicit, and prevent them from silently becoming unreliable required gates.
+
+## Fixtures and test data
+
+- Use synthetic or properly authorized data.
+- Do not commit production secrets, tokens, personal data, or sensitive incident material.
+- Keep fixtures small enough to understand and version.
+- Record the generator or provenance of complex fixtures.
+- Validate generated fixtures when malformed data would weaken the test.
+
+## Flaky tests
+
+A flaky required test is a broken gate, not normal noise.
+
+When flakiness is detected:
+
+1. preserve failure evidence;
+2. identify whether the cause is product behavior, test design, infrastructure, or an external dependency;
+3. fix promptly or quarantine with an owner, issue, rationale, and expiry;
+4. do not convert a required test into a non-blocking check merely to make CI green;
+5. remove quarantine only after repeated evidence of stability.
+
+Retries may collect diagnostic evidence but must not conceal a consistently unreliable result.
+
+## Coverage
+
+Coverage tools may identify untested code, but organization policy does not mandate a universal percentage. Repositories may define thresholds when they are meaningful and resistant to gaming.
+
+Prioritize coverage of:
+
+- public and cross-repository contracts;
+- security and authorization decisions;
+- state transitions and recovery;
+- parsing and untrusted input;
+- compatibility and migration logic;
+- failure behavior with material operational impact.
+
+## Test evidence in pull requests
+
+A pull request should report:
+
+- exact commands or workflows run;
+- relevant environment or platform matrix;
+- results and artifacts;
+- skipped validation and rationale;
+- failures, flakiness, or limitations discovered;
+- follow-up required before release or capability completion.
+
+Do not use “tests pass” when only a subset ran or when the result came from a stale commit.
+
+## Completion
+
+An issue or capability is complete when its acceptance criteria and declared properties are evidenced at the appropriate layers. Passing unit tests alone does not establish integration, release, migration, security, or operational readiness unless those boundaries are genuinely absent.


### PR DESCRIPTION
## Outcome

Establish shared engineering standards for testing, CI/CD, security, releases, documentation, and work-item labels across Micrantha repositories.

## Scope

- add a standards index and local-exception model
- define risk-based testing and validation evidence
- define CI/CD permissions, required-check, self-hosted runner, dependency, artifact, deployment, and release-pipeline expectations
- define security-engineering controls, threat-model triggers, agentic workflow boundaries, evidence, and risk-exception handling
- define versioning, release identity, artifact integrity, compatibility, migration, rollback, security-release, and support expectations
- define documentation requirements by maturity and public-claim categories
- define shared priority, status, type, area, maturity, risk, and pull-request label semantics
- link standards from the root README and contribution guidance

## Design decisions

- standards scale by repository classification, maturity, risk, supported surface, and deployment model
- test counts and coverage percentages do not replace risk-based evidence
- change-aware CI must default conservatively and preserve stable required-check semantics
- self-hosted runners are treated as privileged infrastructure; untrusted fork code must not run on persistent privileged runners
- `mise` may provide the common task interface; `make` is not imposed as an organization requirement
- security, release, and residual-risk authority remains human and attributable
- public documentation distinguishes implemented, experimental, planned, and aspirational claims
- labels support filtering and automation but do not replace durable issue rationale or decision authority

## Validation

- branch created from current `main`
- compared final branch against `main`: nine intended files only
- reviewed relative links among standards, governance, lifecycle, prompts, contribution guidance, and root navigation
- reconciled priority, blocked-status, maturity, release-authority, and public-claim terminology with existing organization guidance
- performed a manual merge-gate review and clarified mature-documentation preservation wording
- confirmed no workflows, repository settings, labels, branch protections, CODEOWNERS, secrets, or runtime code are changed

## Non-goals

- workflow starter templates or reusable workflows
- automated label creation or synchronization
- machine-readable repository metadata
- organization repository-health reporting
- repository-specific CI, release, threat-model, or support configuration

Those remain separate bounded follow-up slices.