### PR TITLE
Add shared automation and repository health foundation

### DIFF
--- a/.github/workflows/meta-validation.yml
+++ b/.github/workflows/meta-validation.yml
@@ -6,6 +6,7 @@ on:
       - .github/workflows/**
       - docs/automation/**
       - metadata/**
+      - tests/**
       - tools/repository_health.py
       - workflow-templates/**
       - mise.toml
@@ -16,6 +17,7 @@ on:
       - .github/workflows/**
       - docs/automation/**
       - metadata/**
+      - tests/**
       - tools/repository_health.py
       - workflow-templates/**
       - mise.toml
@@ -29,7 +31,7 @@ concurrency:
 
 jobs:
   validate:
-    name: registry and templates
+    name: registry, templates, and tests
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -44,3 +46,6 @@ jobs:
 
       - name: Validate metadata and workflow templates
         run: python tools/repository_health.py validate
+
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -v

--- a/.github/workflows/meta-validation.yml
+++ b/.github/workflows/meta-validation.yml
@@ -1,0 +1,46 @@
+name: Meta validation
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/**
+      - docs/automation/**
+      - metadata/**
+      - tools/repository_health.py
+      - workflow-templates/**
+      - mise.toml
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+      - docs/automation/**
+      - metadata/**
+      - tools/repository_health.py
+      - workflow-templates/**
+      - mise.toml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: meta-validation-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: registry and templates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Validate metadata and workflow templates
+        run: python tools/repository_health.py validate

--- a/.github/workflows/repository-health.yml
+++ b/.github/workflows/repository-health.yml
@@ -1,0 +1,72 @@
+name: Repository health
+
+on:
+  workflow_dispatch:
+    inputs:
+      fail-on:
+        description: Optional severity that should fail the workflow
+        required: true
+        type: choice
+        default: none
+        options:
+          - none
+          - error
+          - warning
+  schedule:
+    - cron: "0 16 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repository-health
+  cancel-in-progress: false
+
+jobs:
+  report:
+    name: registry health report
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.ORG_REPOSITORY_READ_TOKEN || github.token }}
+      FAIL_ON: ${{ inputs.fail-on || 'none' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Generate health report
+        id: health
+        continue-on-error: true
+        run: >-
+          python tools/repository_health.py health
+          --fail-on "$FAIL_ON"
+          --output-json artifacts/repository-health.json
+          --output-markdown artifacts/repository-health.md
+
+      - name: Add report to workflow summary
+        if: always()
+        run: |
+          if [[ -f artifacts/repository-health.md ]]; then
+            cat artifacts/repository-health.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Repository health report was not generated." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload health report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: repository-health
+          path: artifacts/repository-health.*
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Enforce selected threshold
+        if: steps.health.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/reusable-mise-ci.yml
+++ b/.github/workflows/reusable-mise-ci.yml
@@ -1,0 +1,54 @@
+name: Reusable mise CI
+
+on:
+  workflow_call:
+    inputs:
+      task:
+        description: Mise task to run
+        required: false
+        type: string
+        default: ci
+      runner:
+        description: GitHub runner label or JSON-compatible runner expression
+        required: false
+        type: string
+        default: ubuntu-latest
+      working-directory:
+        description: Repository-relative working directory
+        required: false
+        type: string
+        default: .
+      mise-version:
+        description: Mise version to install
+        required: false
+        type: string
+        default: 2026.7.13
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: mise / ${{ inputs.task }}
+    runs-on: ${{ inputs.runner }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install tools with mise
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          version: ${{ inputs.mise-version }}
+          working_directory: ${{ inputs.working-directory }}
+          install: true
+          cache: true
+
+      - name: Run mise task
+        env:
+          MISE_TASK: ${{ inputs.task }}
+        run: mise run "$MISE_TASK"

--- a/.github/workflows/reusable-mise-ci.yml
+++ b/.github/workflows/reusable-mise-ci.yml
@@ -9,7 +9,7 @@ on:
         type: string
         default: ci
       runner:
-        description: GitHub runner label or JSON-compatible runner expression
+        description: GitHub runner label
         required: false
         type: string
         default: ubuntu-latest
@@ -36,12 +36,12 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
       - name: Install tools with mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654
         with:
           version: ${{ inputs.mise-version }}
           working_directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-nix-ci.yml
+++ b/.github/workflows/reusable-nix-ci.yml
@@ -1,0 +1,59 @@
+name: Reusable Nix CI
+
+on:
+  workflow_call:
+    inputs:
+      command:
+        description: Nix command to run
+        required: false
+        type: string
+        default: nix flake check --print-build-logs
+      runner:
+        description: GitHub runner label
+        required: false
+        type: string
+        default: ubuntu-latest
+      working-directory:
+        description: Repository-relative working directory
+        required: false
+        type: string
+        default: .
+      extra-nix-config:
+        description: Additional nix.conf settings
+        required: false
+        type: string
+        default: ""
+      enable-kvm:
+        description: Enable KVM when supported by the runner
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: nix / check
+    runs-on: ${{ inputs.runner }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          github_access_token: ${{ github.token }}
+          extra_nix_config: ${{ inputs.extra-nix-config }}
+          enable_kvm: ${{ inputs.enable-kvm }}
+
+      - name: Run Nix validation
+        env:
+          NIX_COMMAND: ${{ inputs.command }}
+        shell: bash
+        run: bash -euo pipefail -c "$NIX_COMMAND"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+artifacts/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Micrantha organization defaults
 
-This repository contains shared governance, community health files, contribution conventions, issue and pull-request templates, engineering prompts, standards, and reusable guidance for repositories in the `hackelia-micrantha` organization.
+This repository contains shared governance, community health files, contribution conventions, issue and pull-request templates, engineering prompts, standards, automation, and reusable guidance for repositories in the `hackelia-micrantha` organization.
 
 Repositories may refine these defaults when their product, legal, security, or operating model requires it, but should document the difference explicitly. Repository-local implementation and evidence remain authoritative within the boundaries assigned by the organization governance model.
 
@@ -29,6 +29,20 @@ The repository catalogue distinguishes architectural authority from runtime depe
   - [Labels and work-item taxonomy](docs/standards/labels.md)
 
 The standards define minimum outcomes according to repository classification, maturity, risk, supported surface, and deployment model. Repository-local standards may be stricter or may document a justified alternative control, but cannot silently weaken security, compatibility, release, support, or public-maturity claims.
+
+## Shared automation and metadata
+
+- [Automation foundation](docs/automation/README.md)
+- [Machine-readable repository registry](metadata/repositories.json)
+- [Repository registry schema](metadata/repositories.schema.json)
+- [Workflow starter templates](workflow-templates/)
+- [Reusable mise CI workflow](.github/workflows/reusable-mise-ci.yml)
+- [Reusable Nix CI workflow](.github/workflows/reusable-nix-ci.yml)
+- [Repository-health workflow](.github/workflows/repository-health.yml)
+
+The automation layer is read-only by default. Starter templates help repositories adopt common workflow structure; repositories still own their tasks, test coverage, runner trust decisions, required checks, and release policy. Shared reusable workflows do not inherit secrets or perform deployment, release, approval, label, or repository-setting mutations.
+
+The repository registry is an advisory machine-readable projection of the canonical responsibility catalogue. A weekly health report checks registered location, visibility, default branch, archival state, and minimal required files without opening issues or modifying repositories. Private-repository coverage requires an explicitly configured read-only token.
 
 ## Engineering work and decisions
 
@@ -110,4 +124,4 @@ Maturity is evidence-based and separate from repository classification:
 - **Superseded**
 - **Archived**
 
-The public aliases `Prototype` and `Maintained` map to `Experimental` and `Maintenance`. Lifecycle changes should update the repository, the [catalogue](docs/architecture/repository-catalogue.md), and relevant public documentation together.
+The public aliases `Prototype` and `Maintained` map to `Experimental` and `Maintenance`. Lifecycle changes should update the repository, the [catalogue](docs/architecture/repository-catalogue.md), registry, and relevant public documentation together.

--- a/docs/automation/README.md
+++ b/docs/automation/README.md
@@ -2,6 +2,8 @@
 
 This directory documents the shared automation surfaces maintained by the Micrantha organization meta repository.
 
+See [automation security boundaries](SECURITY.md) for the caller, input, secret, runner, and token trust model.
+
 ## Scope
 
 The automation foundation provides:

--- a/docs/automation/README.md
+++ b/docs/automation/README.md
@@ -1,0 +1,129 @@
+# Automation foundation
+
+This directory documents the shared automation surfaces maintained by the Micrantha organization meta repository.
+
+## Scope
+
+The automation foundation provides:
+
+- organization workflow starter templates under `workflow-templates/`;
+- reusable, read-only CI workflows under `.github/workflows/`;
+- a machine-readable repository registry under `metadata/`;
+- registry validation and read-only repository-health reporting;
+- explicit adoption and trust-boundary guidance.
+
+It does not automatically modify repository settings, labels, branch protections, secrets, environments, runners, releases, or repository files outside this repository.
+
+## Workflow starter templates
+
+GitHub exposes files in `workflow-templates/` when organization repositories create a new Actions workflow. Each workflow file has a matching `.properties.json` metadata file.
+
+The starter templates intentionally remain small:
+
+- **Mise CI** runs a repository-defined `mise run ci` task through the shared reusable workflow.
+- **Docs CI** runs a repository-defined `mise run docs-ci` task through the same shared workflow.
+- **Nix flake CI** runs `nix flake check --print-build-logs` through the shared Nix workflow.
+
+Repositories own the actual task definitions, test coverage, build graph, and required checks. A starter template is an adoption aid, not proof that the repository satisfies the organization standards.
+
+GitHub replaces `$default-branch` when a starter template is installed. Repositories should review generated event triggers, runner selection, concurrency, permissions, and task names before making the workflow required.
+
+## Reusable workflows
+
+The initial reusable workflows are deliberately narrow:
+
+- `.github/workflows/reusable-mise-ci.yml`
+- `.github/workflows/reusable-nix-ci.yml`
+
+They:
+
+- use read-only `contents` permission;
+- do not inherit or request caller secrets;
+- use GitHub-hosted runners by default;
+- expose bounded inputs for task, command, runner, and working directory;
+- pin external actions to reviewed commit SHAs;
+- avoid deployment, release, mutation, or approval behavior.
+
+Callers should pin reusable workflows to a reviewed release tag or commit SHA before treating them as required production gates. The starter templates use `@main` only as an initial adoption path until a versioned automation release is published.
+
+Permissions can only be maintained or reduced across a reusable workflow chain. A caller remains responsible for granting the minimum permissions required by its complete workflow.
+
+## Repository registry
+
+`metadata/repositories.json` is an advisory machine-readable projection of the canonical [repository responsibility catalogue](../architecture/repository-catalogue.md).
+
+The registry records:
+
+- repository location and visibility;
+- default branch;
+- classification and maturity;
+- authoritative responsibility summary;
+- whether health monitoring is enabled;
+- the minimal files that the health report should verify.
+
+The catalogue and repository-local evidence remain authoritative. Registry changes that alter ownership, maturity, or support claims require the same accountable review as the corresponding documentation changes.
+
+`metadata/repositories.schema.json` supports editors and external validation. `tools/repository_health.py validate` performs dependency-free structural and semantic checks used by CI.
+
+## Repository-health reporting
+
+`.github/workflows/repository-health.yml` runs weekly and on manual dispatch. It is read-only and produces Markdown and JSON reports.
+
+The report checks registered repositories for:
+
+- repository accessibility;
+- visibility, archived state, and default-branch drift;
+- configured required files;
+- registry inconsistencies.
+
+The built-in `GITHUB_TOKEN` can reliably inspect the current repository and public repositories. To include private organization repositories, configure an organization or repository secret named `ORG_REPOSITORY_READ_TOKEN` containing a fine-grained token or GitHub App token with read-only access to the registered repositories and repository contents.
+
+The workflow never opens issues, changes labels, edits repositories, or alters settings. Health findings are evidence for human triage. A missing or inaccessible private repository is reported as unknown when the configured token cannot read it; it is not silently treated as deleted.
+
+## Metadata validation
+
+`.github/workflows/meta-validation.yml` validates:
+
+- registry structure and semantics;
+- workflow-template and `.properties.json` pairing;
+- JSON metadata syntax;
+- known reusable-workflow references from starter templates.
+
+The workflow uses only read permissions and runs on pull requests and pushes to the default branch.
+
+## Label synchronization
+
+Organization-wide label synchronization is intentionally not included in this slice. Label mutation requires explicit credentials, collision handling, repository opt-in, dry-run evidence, and a rollback strategy.
+
+A future label-sync workflow should:
+
+1. read the shared taxonomy from `docs/standards/labels.md` or a derived machine-readable source;
+2. default to dry-run;
+3. require an explicit repository allowlist;
+4. preserve repository-specific labels;
+5. never delete or rename labels without a reviewed migration plan;
+6. use a dedicated least-privilege GitHub App or fine-grained token;
+7. emit a complete before-and-after report.
+
+## Adoption sequence
+
+1. Confirm repository classification, maturity, and authority in the catalogue and registry.
+2. Install the appropriate workflow starter template.
+3. Define repository-owned `mise` tasks or Nix checks.
+4. Review triggers, runners, permissions, and fork behavior.
+5. Run the workflow without making it required.
+6. Reconcile failures and unsupported assumptions.
+7. Pin the reusable workflow to a reviewed version.
+8. Make the stable check name required only after repeatable success.
+
+## Change control
+
+Changes to shared workflows can affect many repositories. Pull requests should identify:
+
+- current callers and expected blast radius;
+- compatibility and migration behavior;
+- runner and action-runtime requirements;
+- permission or secret changes;
+- expected check-name changes;
+- rollback or previous version;
+- validation against at least one representative caller before release.

--- a/docs/automation/SECURITY.md
+++ b/docs/automation/SECURITY.md
@@ -1,0 +1,50 @@
+# Automation security boundaries
+
+Shared automation is a convenience and policy surface, not a new source of repository authority.
+
+## Trust model
+
+- Caller repositories control their workflow triggers, inputs, task definitions, and required-check configuration.
+- Reusable workflows run with the caller's event context and effective permission ceiling.
+- The shared workflows request only read access to repository contents and do not declare secrets.
+- Caller-supplied runner labels, commands, or task names are repository-controlled configuration and must not be populated directly from untrusted issue, pull-request, branch, commit, or dispatch text.
+- Untrusted fork code must not run on persistent privileged self-hosted runners.
+
+## Inputs
+
+Inputs are intended for reviewed workflow configuration. Do not pass untrusted event fields directly into:
+
+- runner selection;
+- working directories;
+- mise task names;
+- Nix commands or configuration;
+- artifact names or paths;
+- deployment or publication targets.
+
+A repository that needs dynamic behavior should validate it against a fixed allowlist before calling a shared workflow.
+
+## Secrets and permissions
+
+The initial reusable workflows do not accept or inherit caller secrets. Adding secrets or write permissions requires a dedicated design and security review covering:
+
+- authority and least privilege;
+- event and fork behavior;
+- protected environments;
+- credential exposure paths;
+- evidence and approval;
+- rollback and incident response;
+- current callers and migration.
+
+## Third-party actions
+
+Third-party actions are pinned to reviewed commit SHAs. Version comments are informational; the SHA is the executed identity. Updates require reviewing release notes, runtime changes, permissions, and supported runner versions.
+
+## Health-report token
+
+`ORG_REPOSITORY_READ_TOKEN` is optional and should be a fine-grained token or GitHub App token limited to read-only metadata and contents for the registered repositories.
+
+The health script does not print the token or API response bodies. It reports inaccessible private repositories as unknown rather than proving absence.
+
+## Reporting vulnerabilities
+
+Follow the organization security policy. Do not include credentials, private repository contents, exploit payloads, or sensitive runner details in public issues or health artifacts.

--- a/metadata/repositories.json
+++ b/metadata/repositories.json
@@ -1,0 +1,246 @@
+{
+  "$schema": "./repositories.schema.json",
+  "schemaVersion": 1,
+  "organization": "hackelia-micrantha",
+  "repositories": [
+    {
+      "repository": "hackelia-micrantha/.github",
+      "classification": "organization-meta",
+      "maturity": "active",
+      "visibility": "public",
+      "defaultBranch": "main",
+      "archived": false,
+      "monitor": true,
+      "authority": [
+        "organization governance and lifecycle",
+        "shared engineering standards",
+        "community-health defaults",
+        "shared prompts and automation templates"
+      ],
+      "requiredFiles": [
+        "README.md",
+        "GOVERNANCE.md",
+        "CONTRIBUTING.md",
+        ".github/SECURITY.md",
+        "docs/architecture/repository-catalogue.md",
+        "docs/governance/repository-lifecycle.md",
+        "docs/standards/README.md"
+      ]
+    },
+    {
+      "repository": "hackelia-micrantha/web",
+      "classification": "public-website",
+      "maturity": "active",
+      "visibility": "public",
+      "defaultBranch": "main",
+      "archived": false,
+      "monitor": true,
+      "authority": [
+        "micrantha.com implementation and deployment"
+      ],
+      "requiredFiles": ["README.md"],
+      "notes": "Public claims must remain projections of authoritative project evidence."
+    },
+    {
+      "repository": "hackelia-micrantha/anthesis",
+      "classification": "solution",
+      "maturity": "incubating",
+      "visibility": "private",
+      "defaultBranch": "main",
+      "archived": false,
+      "monitor": true,
+      "authority": [
+        "governance policy evaluation",
+        "approval and evidence contracts",
+        "governance runtime implementation"
+      ],
+      "requiredFiles": ["README.md"]
+    },
+    {
+      "repository": "hackelia-micrantha/anthesis-community",
+      "classification": "community-surface",
+      "maturity": "incubating",
+      "visibility": "public",
+      "defaultBranch": "main",
+      "archived": false,
+      "monitor": true,
+      "authority": [
+        "public Anthesis documentation and community distribution"
+      ],
+      "requiredFiles": ["README.md"],
+      "notes": "Does not redefine private-source contracts or release evidence."
+    },
+    {
+      "repository": "hackelia-micrantha/hyperion",
+      "classification": "infrastructure",
+      "maturity": "incubating",
+      "visibility": "private",
+      "defaultBranch": "main",
+      "archived": false,
+      "monitor": true,
+      "authority": [
+        "reproducible infrastructure and GitOps implementation"
+      ],
+      "requiredFiles": ["README.md"]
+    },
+    {
+      "repository": "hackelia-micrantha/dubnium-community",
+      "classification": "community-surface",
+      "maturity": "incubating",
+      "visibility": "public",
+      "defaultBranch": "main",
+      "archived": false,
+      "monitor": true,
+      "authority": [
+        "public Dubnium documentation and community distribution"
+      ],
+      "requiredFiles": ["README.md"],
+      "notes": "Distribution composition does not transfer authority over Anthesis or component contracts."
+    },
+    {
+      "repository": "hackelia-micrantha/mobuild-envuscator",
+      "classification": "solution",
+      "maturity": "incubating",
+      "visibility": "private",
+      "defaultBranch": "main",
+      "archived": false,
+      "monitor": true,
+      "authority": [
+        "Envuscator engine and build-time obfuscation implementation"
+      ],
+      "requiredFiles": ["README.md"]
+    },
+    {
+      "repository": "hackelia-micrantha/envuscator-community",
+      "classification": "community-surface",
+      "maturity": "incubating",
+      "visibility": "public",
+      "defaultBranch": "main",
+      "archived": false,
+      "monitor": true,
+      "authority": [
+        "public Envuscator documentation and community distribution"
+      ],
+      "requiredFiles": ["README.md"],
+      "notes": "Licensed provider adapters and private engine behavior remain authoritative in their owning repositories."
+    },
+    {
+      "repository": "hackelia-micrantha/bluebell",
+      "classification": "library-sdk",
+      "maturity": "stable",
+      "visibility": "public",
+      "defaultBranch": "main",
+      "archived": false,
+      "monitor": true,
+      "authority": [
+        "public Kotlin Multiplatform SDK template"
+      ],
+      "requiredFiles": ["README.md"]
+    },
+    {
+      "repository": "hackelia-micrantha/amaryllis",
+      "classification": "library-sdk",
+      "maturity": "experimental",
+      "visibility": "public",
+      "defaultBranch": "main",
+      "archived": false,
+      "monitor": true,
+      "authority": [
+        "mobile inference SDK experiments"
+      ],
+      "requiredFiles": ["README.md"]
+    },
+    {
+      "repository": "hackelia-micrantha/digitalis",
+      "classification": "laboratory",
+      "maturity": "experimental",
+      "visibility": "private",
+      "defaultBranch": "main",
+      "archived": false,
+      "monitor": true,
+      "authority": [
+        "attestation and secure configuration implementation experiments"
+      ],
+      "requiredFiles": ["README.md"]
+    },
+    {
+      "repository": "hackelia-micrantha/digitalis-community",
+      "classification": "community-surface",
+      "maturity": "experimental",
+      "visibility": "public",
+      "defaultBranch": "main",
+      "archived": false,
+      "monitor": true,
+      "authority": [
+        "public Digitalis documentation and demonstrations"
+      ],
+      "requiredFiles": ["README.md"]
+    },
+    {
+      "repository": "hackelia-micrantha/myosotis",
+      "classification": "laboratory",
+      "maturity": "experimental",
+      "visibility": "private",
+      "defaultBranch": "main",
+      "archived": false,
+      "monitor": true,
+      "authority": [
+        "MCP and LLM tool-registry implementation experiments"
+      ],
+      "requiredFiles": ["README.md"]
+    },
+    {
+      "repository": "hackelia-micrantha/myosotis-community",
+      "classification": "community-surface",
+      "maturity": "experimental",
+      "visibility": "public",
+      "defaultBranch": "main",
+      "archived": false,
+      "monitor": true,
+      "authority": [
+        "public Myosotis documentation and demonstrations"
+      ],
+      "requiredFiles": ["README.md"]
+    },
+    {
+      "repository": "hackelia-micrantha/repora",
+      "classification": "repository-tool",
+      "maturity": "incubating",
+      "visibility": "public",
+      "defaultBranch": "main",
+      "archived": false,
+      "monitor": true,
+      "authority": [
+        "repository topology and reconciliation tooling"
+      ],
+      "requiredFiles": ["README.md"]
+    },
+    {
+      "repository": "hackelia-micrantha/fortunes",
+      "classification": "service",
+      "maturity": "stable",
+      "visibility": "private",
+      "defaultBranch": "devel",
+      "archived": false,
+      "monitor": true,
+      "authority": [
+        "Fortunes application composition"
+      ],
+      "requiredFiles": ["README.md"],
+      "notes": "The non-main default branch is recorded explicitly and should be treated as a migration candidate, not silently corrected by automation."
+    },
+    {
+      "repository": "hackelia-micrantha/veil",
+      "classification": "service",
+      "maturity": "experimental",
+      "visibility": "private",
+      "defaultBranch": "main",
+      "archived": false,
+      "monitor": true,
+      "authority": [
+        "image obfuscation and privacy service experiments"
+      ],
+      "requiredFiles": ["README.md"]
+    }
+  ]
+}

--- a/metadata/repositories.schema.json
+++ b/metadata/repositories.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/hackelia-micrantha/.github/blob/main/metadata/repositories.schema.json",
+  "title": "Micrantha repository registry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "organization", "repositories"],
+  "properties": {
+    "schemaVersion": {
+      "const": 1
+    },
+    "organization": {
+      "const": "hackelia-micrantha"
+    },
+    "repositories": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/repository"
+      }
+    }
+  },
+  "$defs": {
+    "repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository",
+        "classification",
+        "maturity",
+        "visibility",
+        "defaultBranch",
+        "archived",
+        "monitor",
+        "authority",
+        "requiredFiles"
+      ],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+        },
+        "classification": {
+          "enum": [
+            "organization-meta",
+            "public-website",
+            "solution",
+            "distribution",
+            "service",
+            "library-sdk",
+            "adapter",
+            "laboratory",
+            "community-surface",
+            "infrastructure",
+            "repository-tool"
+          ]
+        },
+        "maturity": {
+          "enum": [
+            "proposed",
+            "experimental",
+            "incubating",
+            "active",
+            "stable",
+            "maintenance",
+            "superseded",
+            "archived"
+          ]
+        },
+        "visibility": {
+          "enum": ["public", "private", "internal"]
+        },
+        "defaultBranch": {
+          "type": "string",
+          "minLength": 1
+        },
+        "archived": {
+          "type": "boolean"
+        },
+        "monitor": {
+          "type": "boolean"
+        },
+        "authority": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "requiredFiles": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "not": {
+              "pattern": "^/"
+            }
+          }
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/metadata/repositories.schema.json
+++ b/metadata/repositories.schema.json
@@ -6,6 +6,9 @@
   "additionalProperties": false,
   "required": ["schemaVersion", "organization", "repositories"],
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "schemaVersion": {
       "const": 1
     },
@@ -100,7 +103,8 @@
           }
         },
         "notes": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         }
       }
     }

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,14 @@
+[tools]
+python = "3.13"
+
+[tasks.validate]
+description = "Validate repository metadata and workflow-template layout"
+run = "python tools/repository_health.py validate"
+
+[tasks.health]
+description = "Generate a read-only repository-health report"
+run = "python tools/repository_health.py health"
+
+[tasks.ci]
+description = "Run meta-repository validation"
+depends = ["validate"]

--- a/mise.toml
+++ b/mise.toml
@@ -5,10 +5,14 @@ python = "3.13"
 description = "Validate repository metadata and workflow-template layout"
 run = "python tools/repository_health.py validate"
 
+[tasks.test]
+description = "Run automation unit tests"
+run = "python -m unittest discover -s tests -v"
+
 [tasks.health]
 description = "Generate a read-only repository-health report"
 run = "python tools/repository_health.py health"
 
 [tasks.ci]
-description = "Run meta-repository validation"
-depends = ["validate"]
+description = "Run meta-repository validation and tests"
+depends = ["validate", "test"]

--- a/tests/test_repository_health.py
+++ b/tests/test_repository_health.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from tools import repository_health
+
+
+class RegistryValidationTests(unittest.TestCase):
+    def valid_registry(self) -> dict[str, object]:
+        return {
+            "$schema": "./repositories.schema.json",
+            "schemaVersion": 1,
+            "organization": "hackelia-micrantha",
+            "repositories": [
+                {
+                    "repository": "hackelia-micrantha/example",
+                    "classification": "service",
+                    "maturity": "active",
+                    "visibility": "public",
+                    "defaultBranch": "main",
+                    "archived": False,
+                    "monitor": True,
+                    "authority": ["example service"],
+                    "requiredFiles": ["README.md"],
+                }
+            ],
+        }
+
+    def test_valid_registry_has_no_errors(self) -> None:
+        self.assertEqual(repository_health.validate_registry(self.valid_registry()), [])
+
+    def test_duplicate_repository_and_archived_maturity_are_rejected(self) -> None:
+        registry = self.valid_registry()
+        first = registry["repositories"][0]  # type: ignore[index]
+        duplicate = dict(first)  # type: ignore[arg-type]
+        duplicate["maturity"] = "archived"
+        duplicate["archived"] = False
+        registry["repositories"].append(duplicate)  # type: ignore[union-attr]
+
+        errors = repository_health.validate_registry(registry)
+
+        self.assertTrue(any("duplicates" in error for error in errors))
+        self.assertTrue(
+            any("archived maturity but archived is not true" in error for error in errors)
+        )
+
+    def test_unsafe_required_file_path_is_rejected(self) -> None:
+        registry = self.valid_registry()
+        registry["repositories"][0]["requiredFiles"] = ["../secret"]  # type: ignore[index]
+
+        errors = repository_health.validate_registry(registry)
+
+        self.assertTrue(any("unsafe path" in error for error in errors))
+
+
+class WorkflowTemplateValidationTests(unittest.TestCase):
+    def test_matching_workflow_and_properties_are_valid(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            templates = root / "workflow-templates"
+            templates.mkdir()
+            (root / ".github/workflows").mkdir(parents=True)
+            (root / ".github/workflows/reusable-mise-ci.yml").write_text(
+                "name: reusable\n", encoding="utf-8"
+            )
+            (templates / "mise-ci.yml").write_text(
+                "uses: .github/workflows/reusable-mise-ci.yml\n", encoding="utf-8"
+            )
+            (templates / "mise-ci.properties.json").write_text(
+                json.dumps({"name": "Mise CI", "description": "Run CI"}),
+                encoding="utf-8",
+            )
+
+            self.assertEqual(repository_health.validate_workflow_templates(root), [])
+
+    def test_missing_properties_file_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            templates = root / "workflow-templates"
+            templates.mkdir()
+            (templates / "mise-ci.yml").write_text("name: CI\n", encoding="utf-8")
+
+            errors = repository_health.validate_workflow_templates(root)
+
+            self.assertTrue(any("no matching" in error for error in errors))
+
+
+class RepositoryHealthTests(unittest.TestCase):
+    def entry(self, visibility: str = "public") -> dict[str, object]:
+        return {
+            "repository": "hackelia-micrantha/example",
+            "classification": "service",
+            "maturity": "active",
+            "visibility": visibility,
+            "defaultBranch": "main",
+            "archived": False,
+            "monitor": True,
+            "authority": ["example service"],
+            "requiredFiles": ["README.md"],
+        }
+
+    @patch("tools.repository_health.github_request")
+    def test_inaccessible_private_repository_is_unknown(self, request) -> None:
+        request.return_value = (404, None, "Not Found")
+
+        result = repository_health.check_repository(
+            self.entry("private"), "https://api.github.test", "token"
+        )
+
+        self.assertEqual(result["status"], "unknown")
+        self.assertIn("inaccessible", result["findings"][0]["message"])
+
+    @patch("tools.repository_health.github_request")
+    def test_public_missing_required_file_is_error(self, request) -> None:
+        request.side_effect = [
+            (
+                200,
+                {
+                    "visibility": "public",
+                    "default_branch": "main",
+                    "archived": False,
+                },
+                None,
+            ),
+            (404, None, "Not Found"),
+        ]
+
+        result = repository_health.check_repository(
+            self.entry(), "https://api.github.test", None
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("required file missing", result["findings"][0]["message"])
+
+    @patch("tools.repository_health.github_request")
+    def test_matching_repository_is_ok(self, request) -> None:
+        request.side_effect = [
+            (
+                200,
+                {
+                    "visibility": "public",
+                    "default_branch": "main",
+                    "archived": False,
+                },
+                None,
+            ),
+            (200, {}, None),
+        ]
+
+        result = repository_health.check_repository(
+            self.entry(), "https://api.github.test", None
+        )
+
+        self.assertEqual(result["status"], "ok")
+
+    def test_failure_thresholds(self) -> None:
+        summary = {"ok": 1, "skipped": 0, "unknown": 1, "warning": 1, "error": 0}
+
+        self.assertFalse(repository_health.should_fail(summary, "none"))
+        self.assertFalse(repository_health.should_fail(summary, "error"))
+        self.assertTrue(repository_health.should_fail(summary, "warning"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/repository_health.py
+++ b/tools/repository_health.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+"""Validate Micrantha repository metadata and produce a read-only health report."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Iterable
+
+CLASSIFICATIONS = {
+    "organization-meta",
+    "public-website",
+    "solution",
+    "distribution",
+    "service",
+    "library-sdk",
+    "adapter",
+    "laboratory",
+    "community-surface",
+    "infrastructure",
+    "repository-tool",
+}
+MATURITIES = {
+    "proposed",
+    "experimental",
+    "incubating",
+    "active",
+    "stable",
+    "maintenance",
+    "superseded",
+    "archived",
+}
+VISIBILITIES = {"public", "private", "internal"}
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+SEVERITY_ORDER = {"ok": 0, "skipped": 0, "unknown": 1, "warning": 2, "error": 3}
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise ValueError(f"file does not exist: {path}") from None
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"invalid JSON in {path}: line {exc.lineno}, column {exc.colno}: {exc.msg}"
+        ) from None
+
+
+def validate_registry(data: Any, expected_org: str = "hackelia-micrantha") -> list[str]:
+    errors: list[str] = []
+    if not isinstance(data, dict):
+        return ["registry root must be an object"]
+
+    if data.get("schemaVersion") != 1:
+        errors.append("schemaVersion must be 1")
+    if data.get("organization") != expected_org:
+        errors.append(f"organization must be {expected_org!r}")
+
+    repositories = data.get("repositories")
+    if not isinstance(repositories, list):
+        errors.append("repositories must be an array")
+        return errors
+
+    seen: set[str] = set()
+    for index, item in enumerate(repositories):
+        prefix = f"repositories[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+
+        required = {
+            "repository",
+            "classification",
+            "maturity",
+            "visibility",
+            "defaultBranch",
+            "archived",
+            "monitor",
+            "authority",
+            "requiredFiles",
+        }
+        missing = sorted(required - item.keys())
+        if missing:
+            errors.append(f"{prefix} missing required fields: {', '.join(missing)}")
+
+        repository = item.get("repository")
+        if not isinstance(repository, str) or not REPOSITORY_RE.fullmatch(repository):
+            errors.append(f"{prefix}.repository must be an owner/name slug")
+        elif repository in seen:
+            errors.append(f"{prefix}.repository duplicates {repository}")
+        else:
+            seen.add(repository)
+            if not repository.startswith(f"{expected_org}/"):
+                errors.append(
+                    f"{prefix}.repository must belong to {expected_org}: {repository}"
+                )
+
+        if item.get("classification") not in CLASSIFICATIONS:
+            errors.append(
+                f"{prefix}.classification must be one of {sorted(CLASSIFICATIONS)}"
+            )
+        if item.get("maturity") not in MATURITIES:
+            errors.append(f"{prefix}.maturity must be one of {sorted(MATURITIES)}")
+        if item.get("visibility") not in VISIBILITIES:
+            errors.append(f"{prefix}.visibility must be one of {sorted(VISIBILITIES)}")
+
+        default_branch = item.get("defaultBranch")
+        if not isinstance(default_branch, str) or not default_branch.strip():
+            errors.append(f"{prefix}.defaultBranch must be a non-empty string")
+
+        for field in ("archived", "monitor"):
+            if not isinstance(item.get(field), bool):
+                errors.append(f"{prefix}.{field} must be a boolean")
+
+        authority = item.get("authority")
+        if (
+            not isinstance(authority, list)
+            or not authority
+            or any(not isinstance(value, str) or not value.strip() for value in authority)
+        ):
+            errors.append(f"{prefix}.authority must be a non-empty string array")
+        elif len(authority) != len(set(authority)):
+            errors.append(f"{prefix}.authority must not contain duplicates")
+
+        required_files = item.get("requiredFiles")
+        if not isinstance(required_files, list) or any(
+            not isinstance(value, str) or not value.strip() for value in required_files
+        ):
+            errors.append(f"{prefix}.requiredFiles must be a string array")
+        else:
+            if len(required_files) != len(set(required_files)):
+                errors.append(f"{prefix}.requiredFiles must not contain duplicates")
+            for value in required_files:
+                path = Path(value)
+                if path.is_absolute() or ".." in path.parts:
+                    errors.append(
+                        f"{prefix}.requiredFiles contains unsafe path: {value!r}"
+                    )
+
+        maturity = item.get("maturity")
+        archived = item.get("archived")
+        if maturity == "archived" and archived is not True:
+            errors.append(f"{prefix} has archived maturity but archived is not true")
+        if archived is True and maturity != "archived":
+            errors.append(f"{prefix} is archived but maturity is not archived")
+
+        notes = item.get("notes")
+        if notes is not None and not isinstance(notes, str):
+            errors.append(f"{prefix}.notes must be a string when present")
+
+    return errors
+
+
+def validate_workflow_templates(root: Path) -> list[str]:
+    errors: list[str] = []
+    directory = root / "workflow-templates"
+    if not directory.exists():
+        return ["workflow-templates directory does not exist"]
+
+    workflows = {
+        path.stem: path
+        for path in directory.iterdir()
+        if path.is_file() and path.suffix in {".yml", ".yaml"}
+    }
+    properties = {
+        path.name.removesuffix(".properties.json"): path
+        for path in directory.iterdir()
+        if path.is_file() and path.name.endswith(".properties.json")
+    }
+
+    for name, workflow in sorted(workflows.items()):
+        metadata = properties.get(name)
+        if metadata is None:
+            errors.append(f"{workflow} has no matching {name}.properties.json")
+            continue
+        try:
+            value = load_json(metadata)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+        if not isinstance(value, dict):
+            errors.append(f"{metadata} must contain a JSON object")
+            continue
+        for field in ("name", "description"):
+            if not isinstance(value.get(field), str) or not value[field].strip():
+                errors.append(f"{metadata} requires a non-empty {field}")
+        references = [
+            ".github/workflows/reusable-mise-ci.yml",
+            ".github/workflows/reusable-nix-ci.yml",
+        ]
+        text = workflow.read_text(encoding="utf-8")
+        for reference in references:
+            if reference in text and not (root / reference).exists():
+                errors.append(f"{workflow} references missing reusable workflow {reference}")
+
+    for name, metadata in sorted(properties.items()):
+        if name not in workflows:
+            errors.append(f"{metadata} has no matching workflow YAML")
+
+    return errors
+
+
+def validate_all(registry_path: Path, root: Path) -> list[str]:
+    try:
+        registry = load_json(registry_path)
+    except ValueError as exc:
+        return [str(exc)]
+
+    errors = validate_registry(registry)
+    schema_path = registry_path.with_name("repositories.schema.json")
+    try:
+        load_json(schema_path)
+    except ValueError as exc:
+        errors.append(str(exc))
+    errors.extend(validate_workflow_templates(root))
+    return errors
+
+
+def github_request(url: str, token: str | None) -> tuple[int, Any | None, str | None]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "micrantha-repository-health/1",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            body = response.read()
+            value = json.loads(body) if body else None
+            return response.status, value, None
+    except urllib.error.HTTPError as exc:
+        return exc.code, None, exc.reason
+    except urllib.error.URLError as exc:
+        return 0, None, str(exc.reason)
+
+
+def highest_status(findings: Iterable[dict[str, str]], default: str = "ok") -> str:
+    status = default
+    for finding in findings:
+        candidate = finding["status"]
+        if SEVERITY_ORDER[candidate] > SEVERITY_ORDER[status]:
+            status = candidate
+    return status
+
+
+def check_repository(
+    entry: dict[str, Any], api_url: str, token: str | None
+) -> dict[str, Any]:
+    slug = entry["repository"]
+    if not entry["monitor"]:
+        return {
+            "repository": slug,
+            "status": "skipped",
+            "findings": [
+                {"status": "skipped", "message": "monitoring disabled in registry"}
+            ],
+        }
+
+    findings: list[dict[str, str]] = []
+    repo_url = f"{api_url.rstrip('/')}/repos/{slug}"
+    status, repository, error = github_request(repo_url, token)
+
+    if status != 200 or not isinstance(repository, dict):
+        if status == 404 and entry["visibility"] != "public":
+            message = (
+                "private/internal repository is missing or inaccessible to the configured token"
+            )
+            finding_status = "unknown"
+        elif status == 404:
+            message = "public repository was not found"
+            finding_status = "error"
+        else:
+            message = f"repository metadata request failed ({status or 'network'}: {error})"
+            finding_status = "unknown"
+        return {
+            "repository": slug,
+            "status": finding_status,
+            "findings": [{"status": finding_status, "message": message}],
+        }
+
+    actual_visibility = repository.get("visibility")
+    if actual_visibility != entry["visibility"]:
+        findings.append(
+            {
+                "status": "warning",
+                "message": (
+                    f"visibility drift: registry={entry['visibility']}, "
+                    f"github={actual_visibility}"
+                ),
+            }
+        )
+
+    actual_branch = repository.get("default_branch")
+    if actual_branch != entry["defaultBranch"]:
+        findings.append(
+            {
+                "status": "warning",
+                "message": (
+                    f"default branch drift: registry={entry['defaultBranch']}, "
+                    f"github={actual_branch}"
+                ),
+            }
+        )
+
+    actual_archived = bool(repository.get("archived"))
+    if actual_archived != entry["archived"]:
+        findings.append(
+            {
+                "status": "warning",
+                "message": (
+                    f"archived-state drift: registry={entry['archived']}, "
+                    f"github={actual_archived}"
+                ),
+            }
+        )
+
+    for required_file in entry["requiredFiles"]:
+        encoded = urllib.parse.quote(required_file, safe="/")
+        file_url = f"{repo_url}/contents/{encoded}"
+        file_status, _, file_error = github_request(file_url, token)
+        if file_status == 200:
+            continue
+        if file_status == 404:
+            findings.append(
+                {
+                    "status": "error",
+                    "message": f"required file missing: {required_file}",
+                }
+            )
+        else:
+            findings.append(
+                {
+                    "status": "unknown",
+                    "message": (
+                        f"could not verify {required_file} "
+                        f"({file_status or 'network'}: {file_error})"
+                    ),
+                }
+            )
+
+    if not findings:
+        findings.append(
+            {"status": "ok", "message": "registry metadata and required files match"}
+        )
+
+    return {
+        "repository": slug,
+        "status": highest_status(findings),
+        "findings": findings,
+    }
+
+
+def summarize(results: list[dict[str, Any]]) -> dict[str, int]:
+    summary = {key: 0 for key in SEVERITY_ORDER}
+    for result in results:
+        summary[result["status"]] += 1
+    return summary
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    lines = [
+        "# Micrantha repository health",
+        "",
+        f"Generated: `{report['generatedAt']}`",
+        "",
+        (
+            f"**Summary:** {summary['ok']} ok · {summary['warning']} warning · "
+            f"{summary['error']} error · {summary['unknown']} unknown · "
+            f"{summary['skipped']} skipped"
+        ),
+        "",
+        "| Repository | Status | Findings |",
+        "| --- | --- | --- |",
+    ]
+    icons = {
+        "ok": "✅",
+        "warning": "⚠️",
+        "error": "❌",
+        "unknown": "❔",
+        "skipped": "⏭️",
+    }
+    for result in report["repositories"]:
+        findings = "<br>".join(
+            finding["message"].replace("|", "\\|") for finding in result["findings"]
+        )
+        status = result["status"]
+        lines.append(
+            f"| `{result['repository']}` | {icons[status]} {status} | {findings} |"
+        )
+    lines.extend(
+        [
+            "",
+            (
+                "Unknown private-repository results usually mean the configured token "
+                "lacks access; they do not prove that a repository is missing."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def should_fail(summary: dict[str, int], threshold: str) -> bool:
+    if threshold == "none":
+        return False
+    if threshold == "error":
+        return summary["error"] > 0
+    if threshold == "warning":
+        return summary["error"] > 0 or summary["warning"] > 0
+    raise ValueError(f"unsupported threshold: {threshold}")
+
+
+def command_validate(args: argparse.Namespace) -> int:
+    errors = validate_all(args.registry, args.root)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print(
+        f"Validated {args.registry} and workflow templates under "
+        f"{args.root / 'workflow-templates'}"
+    )
+    return 0
+
+
+def command_health(args: argparse.Namespace) -> int:
+    errors = validate_all(args.registry, args.root)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+
+    registry = load_json(args.registry)
+    token = os.environ.get("GITHUB_TOKEN") or None
+    api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+    results = [
+        check_repository(entry, api_url, token) for entry in registry["repositories"]
+    ]
+    report = {
+        "generatedAt": dt.datetime.now(dt.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat(),
+        "organization": registry["organization"],
+        "summary": summarize(results),
+        "repositories": results,
+    }
+
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_markdown.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    markdown = markdown_report(report)
+    args.output_markdown.write_text(markdown, encoding="utf-8")
+    print(markdown)
+
+    return 1 if should_fail(report["summary"], args.fail_on) else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.set_defaults(func=None)
+    subparsers = parser.add_subparsers(dest="command")
+
+    validate_parser = subparsers.add_parser(
+        "validate", help="validate the registry and workflow-template layout"
+    )
+    validate_parser.add_argument(
+        "--registry",
+        type=Path,
+        default=Path("metadata/repositories.json"),
+    )
+    validate_parser.add_argument("--root", type=Path, default=Path("."))
+    validate_parser.set_defaults(func=command_validate)
+
+    health_parser = subparsers.add_parser(
+        "health", help="produce a read-only repository-health report"
+    )
+    health_parser.add_argument(
+        "--registry",
+        type=Path,
+        default=Path("metadata/repositories.json"),
+    )
+    health_parser.add_argument("--root", type=Path, default=Path("."))
+    health_parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("artifacts/repository-health.json"),
+    )
+    health_parser.add_argument(
+        "--output-markdown",
+        type=Path,
+        default=Path("artifacts/repository-health.md"),
+    )
+    health_parser.add_argument(
+        "--fail-on",
+        choices=("none", "error", "warning"),
+        default="none",
+    )
+    health_parser.set_defaults(func=command_health)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.func is None:
+        parser.print_help()
+        return 2
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflow-templates/docs-ci.properties.json
+++ b/workflow-templates/docs-ci.properties.json
@@ -1,0 +1,7 @@
+{
+  "name": "Micrantha Documentation CI",
+  "description": "Run a repository-defined docs-ci mise task through the shared read-only workflow.",
+  "iconName": "octicon book",
+  "categories": ["Continuous integration"],
+  "filePatterns": [".*\\.md$", "^mdbook\\.toml$", "^mkdocs\\.yml$"]
+}

--- a/workflow-templates/docs-ci.yml
+++ b/workflow-templates/docs-ci.yml
@@ -1,0 +1,21 @@
+name: Documentation CI
+
+on:
+  pull_request:
+    branches: [$default-branch]
+  push:
+    branches: [$default-branch]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs:
+    # Define a repository-owned `docs-ci` task, then pin this reusable workflow.
+    uses: hackelia-micrantha/.github/.github/workflows/reusable-mise-ci.yml@main
+    with:
+      task: docs-ci

--- a/workflow-templates/mise-ci.properties.json
+++ b/workflow-templates/mise-ci.properties.json
@@ -1,0 +1,7 @@
+{
+  "name": "Micrantha Mise CI",
+  "description": "Run the repository-defined mise CI task through the shared read-only workflow.",
+  "iconName": "octicon check-circle",
+  "categories": ["Continuous integration"],
+  "filePatterns": ["^mise\\.toml$", "^\\.mise\\.toml$"]
+}

--- a/workflow-templates/mise-ci.yml
+++ b/workflow-templates/mise-ci.yml
@@ -1,0 +1,21 @@
+name: Mise CI
+
+on:
+  pull_request:
+    branches: [$default-branch]
+  push:
+    branches: [$default-branch]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mise-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    # Pin this reusable workflow to a reviewed tag or commit before making it required.
+    uses: hackelia-micrantha/.github/.github/workflows/reusable-mise-ci.yml@main
+    with:
+      task: ci

--- a/workflow-templates/nix-ci.properties.json
+++ b/workflow-templates/nix-ci.properties.json
@@ -1,0 +1,7 @@
+{
+  "name": "Micrantha Nix Flake CI",
+  "description": "Run nix flake check through the shared read-only Nix workflow.",
+  "iconName": "octicon package",
+  "categories": ["Continuous integration", "Nix"],
+  "filePatterns": ["^flake\\.nix$", "^flake\\.lock$"]
+}

--- a/workflow-templates/nix-ci.yml
+++ b/workflow-templates/nix-ci.yml
@@ -1,0 +1,21 @@
+name: Nix flake CI
+
+on:
+  pull_request:
+    branches: [$default-branch]
+  push:
+    branches: [$default-branch]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    # Pin this reusable workflow to a reviewed tag or commit before making it required.
+    uses: hackelia-micrantha/.github/.github/workflows/reusable-nix-ci.yml@main
+    with:
+      command: nix flake check --print-build-logs


### PR DESCRIPTION
## Outcome

Add a conservative shared automation foundation for Micrantha repositories without granting organization-wide mutation authority.

## Scope

- add workflow starter templates for repository-owned mise CI, documentation CI, and Nix flake validation
- add reusable read-only mise and Nix workflows with pinned third-party actions
- add a machine-readable repository registry and JSON schema
- seed the registry with verified core organization repositories, locations, visibility, default branches, maturity, and authority summaries
- add one dependency-free Python tool for registry validation and read-only repository-health reporting
- add focused unit tests for registry semantics, unsafe paths, workflow-template pairing, inaccessible private repositories, missing required files, healthy repositories, and failure thresholds
- add mise tasks for validation, tests, health reporting, and CI
- add a pull-request validation workflow and a weekly/manual repository-health workflow
- add automation adoption, change-control, and security-boundary documentation
- link the automation and metadata surfaces from the root README

## Security and authority

- reusable workflows request only `contents: read`
- reusable workflows do not accept or inherit caller secrets
- external actions are pinned to reviewed commit SHAs
- health reporting is read-only and never opens issues, changes labels, edits repositories, or alters settings
- inaccessible private repositories are reported as unknown rather than treated as deleted
- private-repository coverage is opt-in through `ORG_REPOSITORY_READ_TOKEN`, which should have read-only metadata and contents access
- caller-controlled runner labels, commands, task names, and paths are documented as reviewed workflow configuration and must not be populated directly from untrusted event text
- label synchronization is deliberately deferred until there is an explicit allowlist, dry-run behavior, dedicated credential, migration strategy, and rollback evidence

## Validation

- branch created from current `main`; no divergence
- compared branch against `main`: 19 intended files only
- verified registry locations and visibility through the GitHub connector
- validated pinned action release identities against official action repositories
- compiled and structurally exercised the dependency-free validation tool locally
- validated JSON registry/schema syntax and workflow-template pairing
- added unit tests and made them part of the meta-validation workflow
- manually reviewed workflow permissions, fork and runner boundaries, token handling, threshold behavior, generated-artifact handling, and relative links
- fixed a schema defect where the registry `$schema` field was initially rejected by its own schema
- corrected a misleading reusable-workflow runner-input description

## Adoption model

Starter templates use `@main` only as a bootstrap reference. Repositories should run the workflow without making it required, reconcile assumptions, and pin the reusable workflow to a reviewed release tag or commit before treating its stable job name as a required gate.

## Non-goals

- automatic label creation, rename, deletion, or synchronization
- branch protection, ruleset, environment, runner, secret, or repository-setting changes
- deployment, release, signing, or approval workflows
- repository-specific build logic or CI replacement
- automatic issue creation from health findings

These remain separate, explicitly authorized slices.