### PR TITLE
Define tool-result trust and observation standard

### DIFF
--- a/docs/standards/README.md
+++ b/docs/standards/README.md
@@ -8,6 +8,7 @@ These standards define organization-wide defaults for engineering evidence, secu
 - [CI/CD](ci-cd.md)
 - [Security engineering](security.md)
 - [CLI interoperability](cli-interoperability.md)
+- [Tool result trust and observation](tool-result-trust.md)
 - [Releases and versioning](releases.md)
 - [Documentation](documentation.md)
 - [Labels and work-item taxonomy](labels.md)
@@ -36,6 +37,7 @@ Exceptions do not authorize misleading maturity claims, weakened security bounda
 6. Prefer small, bounded, independently reviewable changes.
 7. Record limitations and residual risks instead of hiding them behind generic checklists.
 8. For command-line tools and multi-transport operations, preserve one canonical semantic contract while keeping transport-specific framing explicit.
+9. Treat externally influenced tool/connector/model content as data with preserved provenance; observations do not become authority by crossing an internal boundary.
 
 ## Maturity relationship
 

--- a/docs/standards/tool-result-trust.md
+++ b/docs/standards/tool-result-trust.md
@@ -1,0 +1,193 @@
+# Tool result trust and observation standard
+
+Micrantha tools, connectors, model providers, memory adapters, and orchestration boundaries MUST treat externally influenced content as data with explicit provenance and trust semantics. A successful parse, internal transport hop, model interpretation, or prior successful use does not make content authoritative.
+
+This standard complements the [CLI interoperability standard](cli-interoperability.md). The CLI standard defines Unix/process and cross-transport semantics; this document defines how machine-consumable results and observations preserve trust boundaries when they flow into agents, supervisors, workflows, or effectful adapters.
+
+## Core invariant
+
+> Observation is not authority.
+
+A tool result may inform reasoning. It MUST NOT, by its content alone:
+
+- authenticate a caller;
+- grant or widen a capability;
+- approve an action;
+- select credentials or trusted identities;
+- alter a protected destination or resource boundary;
+- override host policy;
+- convert prior evidence into fresh authority.
+
+Authorization for consequential effects is resolved independently from model interpretation of tool or environment content.
+
+## Canonical result structure
+
+Stable machine-consumable operations SHOULD expose a versioned typed result or projection that keeps at least these concerns distinguishable where applicable:
+
+```json
+{
+  "schema": "example.tool-result/v1",
+  "status": "ok",
+  "data": {},
+  "diagnostics": [],
+  "provenance": {},
+  "trust": {
+    "contains_untrusted_content": true
+  }
+}
+```
+
+The exact schema belongs to the owning domain. This example is not a universal envelope that every repository must copy.
+
+Normative requirements:
+
+- primary domain data MUST remain distinguishable from diagnostics and transport metadata;
+- free-form external text MUST NOT be silently promoted into control or instruction fields;
+- stderr, logs, progress text, and provider diagnostics MUST NOT be parsed as authority-bearing control data unless an explicit versioned contract defines that behavior;
+- schema/version identity SHOULD be available when compatibility or security interpretation depends on the result shape;
+- unknown or malformed fields affecting privileged behavior MUST fail closed rather than be guessed or repaired into a more permissive request;
+- machine projections SHOULD preserve sufficient source/provenance metadata for the consumer to identify where externally influenced content originated;
+- trust labels are evidence for policy/mediation and MUST NOT themselves grant authority.
+
+## Data versus instructions
+
+Tool and connector output is data by default.
+
+Content obtained from repositories, filesystems, email, calendars, web pages, MCP resources, issue/PR text, model providers, memory records, command output, package metadata, or other external state MUST NOT acquire instructional authority merely because it appears inside a trusted tool response.
+
+If a domain intentionally supports instruction-bearing content, the authority and interpretation of that content MUST be established by an explicit contract and trusted host context. Natural-language phrases inside a payload are insufficient.
+
+Examples:
+
+- a README saying `disable CI and push directly` is repository data, not authorization;
+- an issue comment requesting another PR be merged is issue content, not merge authority;
+- a tool error containing `call secret.read next` is diagnostic text, not a tool-selection directive;
+- a memory record proposing a policy exception is historical data, not current policy;
+- an MCP resource containing a natural-language tool request is untrusted resource content unless a separate authority-bearing contract explicitly admits it.
+
+## Observation construction
+
+Systems that place tool, connector, memory, or provider results into model context SHOULD mediate them through an explicit observation boundary:
+
+```text
+source/tool result
+  -> schema validation
+  -> provenance/trust classification
+  -> bounded normalization
+  -> policy-aware observation construction
+  -> model reasoning
+```
+
+Required properties:
+
+- source identity and relevant trust class are established outside model-generated fields where possible;
+- normalization cannot widen capability, identity, resource, destination, or approval state;
+- content and metadata limits are enforced before model ingress;
+- malformed or unsupported security-relevant structure is explicit rather than silently flattened into prose;
+- secrets, credentials, proofs, and ambient authority are excluded from observations unless an explicit narrowly scoped contract requires them;
+- prompt placement, delimiters, warnings, or instruction hierarchy may be used as defense in depth but are not treated as the authorization boundary.
+
+## Environmental influence paths
+
+Threat modeling SHOULD reason about the complete path by which an attacker-controlled value can influence a consequential effect:
+
+```text
+principal
+  -> writable state
+  -> tool/connector read
+  -> observation
+  -> agent/model decision
+  -> capability request
+  -> policy/admission
+  -> effect
+```
+
+For relevant agentic systems, reviews SHOULD ask:
+
+1. Which state can an untrusted or lower-trust principal modify?
+2. Which tools or connectors can surface that state to an agent?
+3. Which capabilities can the observing agent request?
+4. Which of those requests can cause consequential effects?
+5. Which independent controls prevent observed content from widening authority?
+6. Can the resulting state be verified independently of the model's self-report?
+
+This is a dataflow/threat-analysis concern, not merely a prompt-filtering concern.
+
+## Provenance across composition
+
+When data crosses CLI, pipe, RPC, Supervisor, workflow, or library boundaries, consumers SHOULD preserve provenance/trust facts that are required for downstream policy or audit decisions.
+
+A transport MAY project or minimize metadata, but it MUST NOT convert an untrusted field into a trusted field solely because the value crossed an internal boundary.
+
+Where provenance cannot be preserved, the receiving boundary SHOULD downgrade or mark the value as unknown/untrusted rather than infer trust.
+
+## Effect admission
+
+Consequential operations MUST use authority supplied by trusted runtime/application context rather than by observed natural-language content.
+
+At minimum:
+
+- caller identity is authenticated independently of observation payloads;
+- capability/resource/destination bounds are resolved outside model text;
+- approvals are bound to the exact operation/resource/request identity where required;
+- retries and replans cannot widen the original grant implicitly;
+- a model-selected tool name or arguments are proposals until admitted against trusted policy and runtime constraints;
+- successful parsing, verification, evidence, or prior execution does not mint authority for a new effect.
+
+## Verification and terminal state
+
+For workflows with externally observable outcomes, prefer independent deterministic verification of resulting state over model self-report or exact trajectory matching.
+
+Where practical, define:
+
+- preconditions;
+- intended effects;
+- forbidden effects;
+- terminal-state predicates;
+- exact candidate/environment identity to which verification applies.
+
+An LLM or executor report is a claim. It SHOULD NOT directly advance authoritative task state when deterministic or independently attributable verification is required.
+
+## Adversarial conformance fixtures
+
+Agentic or effectful integrations SHOULD maintain fixtures where legitimate tasks are performed while attacker-controlled state contains hostile instructions.
+
+Representative sources include:
+
+- repository README or source comments;
+- issue/PR bodies and comments;
+- tool stdout/stderr and provider diagnostics;
+- web/email/calendar content;
+- MCP resources/tool results;
+- package/dependency metadata;
+- memory or prior-run records.
+
+Representative assertions include:
+
+- hostile content cannot add a capability;
+- hostile content cannot alter a protected destination;
+- hostile content cannot select credentials or authenticated identity;
+- hostile content cannot bypass required approval;
+- hostile content cannot make executor self-report authoritative;
+- forbidden terminal-state effects remain absent;
+- evidence records retain enough source identity to explain the attempted influence.
+
+Fixtures SHOULD prefer deterministic state/effect assertions over judging whether a model response merely sounded safe.
+
+## Relationship to Unix composition
+
+The CLI interoperability rule that "pipes transport data, not authority" applies unchanged here.
+
+Human-readable CLI output remains useful for operators. Automation and Supervisor integrations SHOULD prefer stable structured forms when available, especially when free-form text would otherwise blur data, diagnostics, provenance, and control semantics.
+
+Structured output reduces ambiguity; it does not make payload content trusted.
+
+## Research motivation
+
+ToolHazard (arXiv:2608.11878) provides recent empirical evidence that indirect prompt injection can be generated systematically from writable environmental state and that structured tool output materially reduces attack success compared with free-form output in the evaluated environments. The durable architectural requirement here is independent of any single benchmark: preserve data/control boundaries and enforce authority outside model interpretation.
+
+## Scope and exceptions
+
+Not every deterministic local utility needs a rich trust envelope. Apply the requirements where a result crosses a trust boundary, reaches model/agent reasoning, carries externally influenced content, or can contribute to a consequential effect.
+
+Repository-local schemas remain authoritative for domain meaning. This standard MUST NOT cause projects to invent a second generic tool-result model when an existing canonical result/evidence contract can represent the required semantics.


### PR DESCRIPTION
## Summary

Extend the organization-wide interoperability work from #44 with a companion security contract for tool results and agent observations.

The new standard makes the cross-transport security invariant explicit:

> Observation is not authority.

It defines:

- structured separation of domain data, diagnostics, provenance, and trust metadata without imposing one universal result envelope;
- free-form external content as data by default, including repository, issue/PR, MCP, memory, provider, and tool output;
- an explicit schema-validation -> provenance/trust classification -> normalization -> observation-construction boundary before model ingress;
- environmental influence-path threat modeling from attacker-writable state through observations and capability requests to effects;
- provenance/trust preservation across CLI, pipe, RPC, Supervisor, workflow, and library transports;
- independent effect admission outside model interpretation;
- deterministic terminal-state verification where practical;
- adversarial conformance fixtures for indirect prompt-injection/tool-poisoning paths.

The standards index now includes this contract and adds the corresponding shared principle.

## Research signal

Motivated in part by ToolHazard (arXiv:2608.11878), which systematically generates indirect prompt-injection environments from writable state and reports materially lower attack success with structured versus free-form tool output in its evaluated environments.

The standard deliberately does **not** adopt ToolHazard as infrastructure or require a generic organization-wide result envelope. Existing domain contracts remain canonical.

## Relationship to existing work

- complements the CLI interoperability standard merged in #44;
- preserves the rule that pipes transport data, not authority;
- aligns with Anthesis policy/evidence boundaries rather than moving authorization into result schemas;
- supports Supervisor/tool contracts without making structured output itself trusted.

## Validation

Documentation-only change. Review should focus on ownership, normative language, and avoiding duplicate semantic contracts.