### PR TITLE
ci: refresh repository health after registry changes

### DIFF
--- a/.github/workflows/repository-health.yml
+++ b/.github/workflows/repository-health.yml
@@ -12,6 +12,15 @@ on:
           - none
           - error
           - warning
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/repository-health.yml
+      - docs/automation/repository-registry-coverage.md
+      - metadata/repositories.json
+      - metadata/repositories.schema.json
+      - tools/repository_health.py
   schedule:
     - cron: "0 16 * * 1"
 


### PR DESCRIPTION
## Outcome

Produce a current repository-health baseline whenever the reviewed health scope or health implementation lands on `main`, instead of waiting for the weekly schedule.

Related: #26.

## Change

Add a narrow `push` trigger on `main` for:

- `.github/workflows/repository-health.yml`;
- `docs/automation/repository-registry-coverage.md`;
- `metadata/repositories.json`;
- `metadata/repositories.schema.json`;
- `tools/repository_health.py`.

Existing weekly and manual triggers remain unchanged.

## Safety

- health remains read-only (`contents: read`);
- default `fail-on` remains `none`, so baseline findings are evidence rather than a new deployment gate;
- no `pull_request` trigger is added, avoiding private sibling-repository credential use in arbitrary PR execution;
- private repositories remain `unknown` when no optional read-only organization token is configured.

## Why

The latest scheduled health run predates the September registry/census refresh. Merging this change will trigger a current-head baseline automatically and will keep future registry/tool changes from waiting up to a week for fresh evidence.