### PR TITLE
ci: bound reusable workflow runtimes

### DIFF
--- a/.github/workflows/reusable-mise-ci.yml
+++ b/.github/workflows/reusable-mise-ci.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: string
         default: 2026.7.13
+      timeout_minutes:
+        description: Maximum minutes for the delegated CI job
+        required: false
+        type: number
+        default: 30
 
 permissions:
   contents: read
@@ -31,6 +36,7 @@ jobs:
   ci:
     name: mise / ${{ inputs.task }}
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-nix-ci.yml
+++ b/.github/workflows/reusable-nix-ci.yml
@@ -28,6 +28,11 @@ on:
         required: false
         type: boolean
         default: false
+      timeout_minutes:
+        description: Maximum minutes for the delegated Nix job
+        required: false
+        type: number
+        default: 30
 
 permissions:
   contents: read
@@ -36,6 +41,7 @@ jobs:
   check:
     name: nix / check
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
## Outcome

Make timeout ownership explicit inside reusable workflows, where GitHub supports it for delegated jobs.

Related: #25.

## Change

- add `timeout_minutes` input to reusable Mise CI, default 30;
- add `timeout_minutes` input to reusable Nix CI, default 30;
- apply the input as `timeout-minutes` on the called workflow's actual runner job.

## Why

The Repora pilot proved its repository policy correctly expects bounded jobs, but GitHub does not allow `timeout-minutes` on a caller job whose top-level `uses:` invokes a reusable workflow. The timeout must therefore be owned by the called workflow.

This is a backward-compatible shared-workflow API addition. Existing callers retain current behavior except that delegated jobs are now bounded at 30 minutes by default and may request a different reviewed bound.