### PR TITLE
docs: record completed Mise pilot evidence

### DIFF
--- a/docs/automation/versioning.md
+++ b/docs/automation/versioning.md
@@ -24,9 +24,10 @@ This revision contains the reusable Mise and Nix workflows with read-only permis
 Pilot evidence:
 
 - **Repora / Nix** — the shared Nix workflow passed on PR #163 and again on `main` after merge, using the same immutable shared-workflow revision. The pilot also exposed and repaired a repository-local workflow-policy assumption: caller jobs that delegate via top-level `uses:` cannot own `timeout-minutes`; the called reusable workflow must own the runtime bound.
-- **Anthesis / Mise** — the shared Mise workflow passed on PR #235 on the existing `runner-anthesis` self-hosted boundary, with direct fork execution rejected and a 15-minute delegated timeout. Default-branch repeat evidence is required after merge before the Mise pilot is considered complete.
+- **Repora / Mise** — the shared Mise workflow passed on PR #164 and again on `main` after merge, using repository-owned `mise run test`, GitHub-hosted execution, read-only permissions, and a 15-minute delegated timeout. This supplies repeatable PR/default-branch evidence for the Mise workflow family without depending on private runner availability.
+- **Anthesis / Mise trust boundary** — PR #235 separately proved that the same shared Mise workflow can preserve the existing `runner-anthesis` self-hosted boundary, direct-fork rejection, read-only permissions, and a 15-minute delegated timeout. Its repository-local required CI remains independently gated by Anthesis JIT capacity and is not required to establish the already-complete shared-workflow repeatability evidence above.
 
-Publication of the convenience tag `automation-v1.0.0` remains a separate final release action. Until that tag exists, callers should continue using the immutable candidate SHA.
+Both reusable workflow families therefore have repeatable caller evidence on the same immutable candidate. Publication and verification of the convenience tag `automation-v1.0.0` is the only remaining release action. Until that tag exists, callers should continue using the immutable candidate SHA.
 
 ## Compatibility policy
 


### PR DESCRIPTION
## Outcome

Reconcile the shared-automation versioning document with completed Repora Mise PR + default-branch evidence.

Related: #25.

## Evidence now recorded

- Repora Nix: PR #163 + `main`, same immutable candidate;
- Repora Mise: PR #164 + `main`, same immutable candidate and repository-owned `mise run test`;
- Anthesis #235 remains separate self-hosted/fork-boundary evidence and stays repository-locally CI-gated;
- both reusable workflow families now have repeatable caller evidence;
- publication and verification of `automation-v1.0.0` is the sole remaining #25 release action.

No workflow implementation or authority boundary changes are included.