### PR TITLE
Model source exposure and distribution posture in repository metadata

### DIFF
--- a/.github/workflows/meta-validation.yml
+++ b/.github/workflows/meta-validation.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths:
       - .github/workflows/**
+      - docs/architecture/**
       - docs/automation/**
       - docs/prompts/**
       - metadata/**
       - tests/**
       - tools/repository_health.py
+      - tools/source_posture.py
       - workflow-templates/**
       - mise.toml
   push:
@@ -16,11 +18,13 @@ on:
       - main
     paths:
       - .github/workflows/**
+      - docs/architecture/**
       - docs/automation/**
       - docs/prompts/**
       - metadata/**
       - tests/**
       - tools/repository_health.py
+      - tools/source_posture.py
       - workflow-templates/**
       - mise.toml
 
@@ -33,7 +37,7 @@ concurrency:
 
 jobs:
   validate:
-    name: registry, prompts, templates, and tests
+    name: registry, posture, prompts, templates, and tests
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -48,6 +52,9 @@ jobs:
 
       - name: Validate metadata and workflow templates
         run: python tools/repository_health.py validate
+
+      - name: Validate source and distribution posture
+        run: python tools/source_posture.py metadata/repositories.json
 
       - name: Run unit tests
         run: python -m unittest discover -s tests -v

--- a/docs/architecture/source-exposure-topologies.md
+++ b/docs/architecture/source-exposure-topologies.md
@@ -1,0 +1,250 @@
+# Source exposure and distribution topologies
+
+> **Status:** non-normative architecture guide.  
+> **Normative policy:** [`../standards/source-exposure-and-distribution.md`](../standards/source-exposure-and-distribution.md)  
+> **Release contract:** [`../standards/releases.md`](../standards/releases.md)  
+> **CLI contract:** [`../standards/cli-interoperability.md`](../standards/cli-interoperability.md)
+
+This guide makes Micrantha repository topology easier to reason about without turning repository names or GitHub visibility into authority.
+
+The important rule is that these questions are independent:
+
+1. Is implementation source intentionally public?
+2. What role does this repository play?
+3. Which repository owns implementation truth?
+4. Which repository/release process authorizes releases?
+5. How do downstream consumers obtain the product?
+
+A `-community` suffix answers none of those questions by itself.
+
+## Machine-readable dimensions
+
+The repository registry may classify a repository with the following orthogonal fields:
+
+```yaml
+sourceExposure: public | private | none
+repositoryRole: canonical | distribution | projection | mirror | internal | meta
+implementationAuthority: owner/repository | null
+releaseAuthority: owner/repository | null
+distributionMode: source | binary | package | closure | internal | none
+canonicalRepository: owner/repository | null
+publicDistributionRepository: owner/repository | null
+```
+
+During migration these fields are optional. Once any primary posture field is present, `sourceExposure`, `repositoryRole`, and `distributionMode` must be declared together.
+
+`visibility` remains separate. It describes GitHub access, not product authority or source-disclosure intent.
+
+## Topology A — public-source canonical project
+
+Use this when the authoritative implementation is deliberately public.
+
+```text
+public canonical repository
+  implementation authority
+  release authority
+  sourceExposure=public
+  repositoryRole=canonical
+  distributionMode=source
+        |
+        v
+source-building package / flake
+        |
+        v
+consumers
+```
+
+Typical examples include a reusable open-source tool or SDK whose public repository is also implementation truth.
+
+A source-building Nix flake is appropriate here because source availability is part of the intended product boundary.
+
+## Topology B — private canonical + public binary distribution
+
+Use this when implementation remains private but unauthenticated/public consumers should be able to install releases.
+
+```text
+private canonical repository
+  sourceExposure=private
+  repositoryRole=canonical
+  implementation/release authority
+        |
+        | authorized reviewed release
+        v
+immutable binary artifact
+  + checksums/signature/provenance
+  + public CLI/schema/man-page contracts
+        |
+        v
+public distribution repository
+  sourceExposure=none
+  repositoryRole=distribution
+  distributionMode=binary
+        |
+        v
+binary-oriented package / Nix flake
+        |
+        v
+consumers
+```
+
+**Invokrum** is the reference migration for this topology. The production Anthesis CLI is expected to use the same broad distribution shape once its Rust-native product boundary is stable.
+
+A public source-building flake that recompiles the intentionally private implementation would contradict this topology.
+
+## Topology C — private canonical + public source projection
+
+Use this when canonical authority remains private but selected implementation/contracts are deliberately projected as public source.
+
+```text
+private canonical repository
+  sourceExposure=private
+  repositoryRole=canonical
+        |
+        | reviewed one-way projection
+        v
+public projection repository
+  sourceExposure=public
+  repositoryRole=projection
+  distributionMode=source
+        |
+        +--> public consumers
+        +--> public contribution/reconciliation path
+```
+
+**Keylix** demonstrates why public source exposure does not imply public canonical authority.
+
+The projection must have a documented reconciliation/publication direction. It must not silently become a second implementation truth.
+
+## Topology D — public canonical reusable core + private composition
+
+Use this when the reusable implementation itself is intentionally public while private repositories hold product data, deployment composition, or non-public extensions.
+
+```text
+public reusable core
+  sourceExposure=public
+  repositoryRole=canonical
+  distributionMode=source
+        |
+        +--> external consumers
+        +--> private composition repository
+                  sourceExposure=private
+                  repositoryRole=internal
+                  distributionMode=internal
+```
+
+**Calathea** is the reference case: the public reusable core owns deterministic reusable semantics while private composition must not fork that public canonical behavior.
+
+This topology is not a private-canonical/public-community split even if repository naming looks similar.
+
+## Topology E — private canonical + curated public contract/community projection
+
+Use this when a project wants public documentation, schemas, examples, interoperability material, or community discussion without exposing implementation source or necessarily distributing an executable.
+
+```text
+private canonical repository
+  sourceExposure=private
+  repositoryRole=canonical
+        |
+        | explicit allow-listed publication
+        v
+public projection/community repository
+  sourceExposure=none or public   # depends on what is deliberately published
+  repositoryRole=projection
+  distributionMode=none/source/package
+```
+
+**Sandcastle** currently uses this broad boundary. Automated publication remains a separately governed effect and must fail closed.
+
+A public projection is not automatically a package repository.
+
+## Topology F — multi-repository engine, adapters, and public distribution
+
+Some projects have more than one private implementation authority because different repositories own different bounded contexts.
+
+```text
+private engine/core authority ----+
+private provider adapters --------+----> reviewed release set
+private entitlement/delivery -----+              |
+                                                 v
+                                    public docs / verification /
+                                    release metadata / facade
+```
+
+**Envuscator** is an example where engine/runtime, provider adapters, delivery/entitlement, and public community surfaces must be modeled as explicit edges instead of collapsed into one `canonical` repository.
+
+For these systems, registry metadata should describe the authority edges that actually exist. Do not manufacture a single canonical repository merely to simplify a diagram.
+
+## Choosing a Nix/package surface
+
+| Source posture | Appropriate downstream package shape |
+| --- | --- |
+| public canonical source | source-building flake/package is normally appropriate |
+| private canonical + public binary distribution | public flake fetches immutable release artifacts and pins hashes |
+| private canonical + public source projection | source-building public package is allowed only for deliberately projected source |
+| private internal-only component | trusted build/materialization boundary; distribute closure/image/package as needed |
+| curated public docs/contracts only | no executable package is implied |
+
+Nix reproducibility does not require public implementation source. For a private implementation, reproducibility can be split between a private canonical build/release pipeline and a public artifact package that verifies immutable bytes and provenance.
+
+## Release identity
+
+For one immutable release, avoid multiple independent version authorities:
+
+```text
+canonical source revision/tag
+  = executable --version
+  = archive/package metadata
+  = man-page release metadata
+  = public package/flake version
+  = checksum/signature/provenance subject
+  = downstream pinned package identity
+```
+
+If a man page or generated package cannot safely derive a version from the canonical release identity, omitting redundant static version text is safer than allowing drift.
+
+## Authority does not flow through packaging
+
+These statements remain true in every topology:
+
+- package installation is not capability or effect authorization;
+- artifact validity is evidence, not runtime authority;
+- a public distribution repository does not become implementation authority merely because it hosts releases;
+- a mirror or projection does not become release authority merely because it contains source;
+- private source does not make an insecure design secure;
+- signing keys and privileged credentials belong at protected release/effect boundaries, never in distributed binaries or ordinary PR workflows.
+
+## Publication and history
+
+Changing the forward boundary does not erase earlier disclosure.
+
+If implementation source was previously public:
+
+- treat public Git history, forks, caches, downloaded archives, and derived analysis as prior disclosure;
+- do not claim that deleting files from the current branch makes them secret again;
+- use the new boundary to protect future implementation evolution;
+- make history rewriting a separate explicit decision if it is ever required.
+
+## Anti-patterns
+
+Avoid:
+
+- interpreting `-community` as `distribution`, `projection`, or `canonical` without metadata;
+- interpreting `visibility=public` as `sourceExposure=public`;
+- exporting private implementation source solely so a public Nix flake can build it;
+- requiring ordinary downstream endpoints to possess private source credentials when they only need released artifacts;
+- allowing a public projection to silently fork canonical contracts;
+- using package/signature validity as governance authorization;
+- duplicating release versions independently in Cargo/npm metadata, Nix, man pages, release workflows, and provenance;
+- publishing private Git history when a clean curated public surface is intended.
+
+## Rollout
+
+Machine-readable rollout is tracked by `.github#66`; ecosystem classification is tracked by `hackelia-micrantha/hackelia-micrantha#35`.
+
+The migration order should be evidence-driven:
+
+1. classify projects with active packaging/release work;
+2. validate reference topologies (Invokrum, Keylix, Calathea, curated projection);
+3. add release/readiness checks for contradictions that are mechanically decidable;
+4. migrate remaining repositories incrementally;
+5. only make posture metadata universally required once the registry is complete enough to avoid a flag-day migration.

--- a/metadata/repositories.schema.json
+++ b/metadata/repositories.schema.json
@@ -6,23 +6,19 @@
   "additionalProperties": false,
   "required": ["schemaVersion", "organization", "repositories"],
   "properties": {
-    "$schema": {
-      "type": "string"
-    },
-    "schemaVersion": {
-      "const": 1
-    },
-    "organization": {
-      "const": "hackelia-micrantha"
-    },
+    "$schema": {"type": "string"},
+    "schemaVersion": {"const": 1},
+    "organization": {"const": "hackelia-micrantha"},
     "repositories": {
       "type": "array",
-      "items": {
-        "$ref": "#/$defs/repository"
-      }
+      "items": {"$ref": "#/$defs/repository"}
     }
   },
   "$defs": {
+    "repositoryRef": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+    },
     "repository": {
       "type": "object",
       "additionalProperties": false,
@@ -37,11 +33,13 @@
         "authority",
         "requiredFiles"
       ],
+      "dependentRequired": {
+        "sourceExposure": ["repositoryRole", "distributionMode"],
+        "repositoryRole": ["sourceExposure", "distributionMode"],
+        "distributionMode": ["sourceExposure", "repositoryRole"]
+      },
       "properties": {
-        "repository": {
-          "type": "string",
-          "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
-        },
+        "repository": {"$ref": "#/$defs/repositoryRef"},
         "classification": {
           "enum": [
             "organization-meta",
@@ -69,27 +67,15 @@
             "archived"
           ]
         },
-        "visibility": {
-          "enum": ["public", "private", "internal"]
-        },
-        "defaultBranch": {
-          "type": "string",
-          "minLength": 1
-        },
-        "archived": {
-          "type": "boolean"
-        },
-        "monitor": {
-          "type": "boolean"
-        },
+        "visibility": {"enum": ["public", "private", "internal"]},
+        "defaultBranch": {"type": "string", "minLength": 1},
+        "archived": {"type": "boolean"},
+        "monitor": {"type": "boolean"},
         "authority": {
           "type": "array",
           "minItems": 1,
           "uniqueItems": true,
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
+          "items": {"type": "string", "minLength": 1}
         },
         "requiredFiles": {
           "type": "array",
@@ -97,15 +83,38 @@
           "items": {
             "type": "string",
             "minLength": 1,
-            "not": {
-              "pattern": "^/"
-            }
+            "not": {"pattern": "^/"}
           }
         },
-        "notes": {
-          "type": "string",
-          "minLength": 1
-        }
+        "sourceExposure": {
+          "description": "Whether implementation source intentionally exposed by this repository is public, private, or not applicable to this surface.",
+          "enum": ["public", "private", "none"]
+        },
+        "repositoryRole": {
+          "description": "The repository's topology role, independent of GitHub visibility.",
+          "enum": ["canonical", "distribution", "projection", "mirror", "internal", "meta"]
+        },
+        "implementationAuthority": {
+          "description": "Repository that owns authoritative implementation semantics when different from this surface.",
+          "oneOf": [{"$ref": "#/$defs/repositoryRef"}, {"type": "null"}]
+        },
+        "releaseAuthority": {
+          "description": "Repository whose reviewed release process authorizes releases for this surface.",
+          "oneOf": [{"$ref": "#/$defs/repositoryRef"}, {"type": "null"}]
+        },
+        "distributionMode": {
+          "description": "Primary downstream acquisition mode represented by this repository.",
+          "enum": ["source", "binary", "package", "closure", "internal", "none"]
+        },
+        "canonicalRepository": {
+          "description": "Explicit canonical repository edge when this surface is a projection, distribution, or mirror.",
+          "oneOf": [{"$ref": "#/$defs/repositoryRef"}, {"type": "null"}]
+        },
+        "publicDistributionRepository": {
+          "description": "Explicit public distribution/projection edge when this repository owns canonical implementation or release authority.",
+          "oneOf": [{"$ref": "#/$defs/repositoryRef"}, {"type": "null"}]
+        },
+        "notes": {"type": "string", "minLength": 1}
       }
     }
   }

--- a/mise.toml
+++ b/mise.toml
@@ -2,8 +2,8 @@
 python = "3.13"
 
 [tasks.validate]
-description = "Validate repository metadata and workflow-template layout"
-run = "python tools/repository_health.py validate"
+description = "Validate repository metadata, source posture, and workflow-template layout"
+run = "python tools/repository_health.py validate && python tools/source_posture.py metadata/repositories.json"
 
 [tasks.test]
 description = "Run automation unit tests"

--- a/tests/test_source_posture.py
+++ b/tests/test_source_posture.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import unittest
+
+from tools import source_posture
+
+
+class SourcePostureValidationTests(unittest.TestCase):
+    def registry(self, *repositories: dict[str, object]) -> dict[str, object]:
+        return {
+            "schemaVersion": 1,
+            "organization": "hackelia-micrantha",
+            "repositories": list(repositories),
+        }
+
+    def entry(
+        self,
+        repository: str,
+        *,
+        visibility: str,
+        source_exposure: str | None = None,
+        repository_role: str | None = None,
+        distribution_mode: str | None = None,
+        **extra: object,
+    ) -> dict[str, object]:
+        item: dict[str, object] = {
+            "repository": repository,
+            "visibility": visibility,
+        }
+        if source_exposure is not None:
+            item["sourceExposure"] = source_exposure
+        if repository_role is not None:
+            item["repositoryRole"] = repository_role
+        if distribution_mode is not None:
+            item["distributionMode"] = distribution_mode
+        item.update(extra)
+        return item
+
+    def test_unclassified_legacy_entries_are_permitted_during_rollout(self) -> None:
+        data = self.registry(
+            self.entry("hackelia-micrantha/legacy", visibility="private")
+        )
+
+        self.assertEqual(source_posture.validate_registry_posture(data), [])
+
+    def test_invokrum_private_canonical_and_public_binary_distribution_are_valid(self) -> None:
+        canonical = self.entry(
+            "hackelia-micrantha/invokrum",
+            visibility="private",
+            source_exposure="private",
+            repository_role="canonical",
+            distribution_mode="binary",
+            implementationAuthority="hackelia-micrantha/invokrum",
+            releaseAuthority="hackelia-micrantha/invokrum",
+            publicDistributionRepository="hackelia-micrantha/invokrum-community",
+        )
+        distribution = self.entry(
+            "hackelia-micrantha/invokrum-community",
+            visibility="public",
+            source_exposure="none",
+            repository_role="distribution",
+            distribution_mode="binary",
+            implementationAuthority="hackelia-micrantha/invokrum",
+            releaseAuthority="hackelia-micrantha/invokrum",
+            canonicalRepository="hackelia-micrantha/invokrum",
+        )
+
+        self.assertEqual(
+            source_posture.validate_registry_posture(
+                self.registry(canonical, distribution)
+            ),
+            [],
+        )
+
+    def test_keylix_private_canonical_and_public_source_projection_are_valid(self) -> None:
+        canonical = self.entry(
+            "hackelia-micrantha/keylix",
+            visibility="private",
+            source_exposure="private",
+            repository_role="canonical",
+            distribution_mode="binary",
+            publicDistributionRepository="hackelia-micrantha/keylix-community",
+        )
+        projection = self.entry(
+            "hackelia-micrantha/keylix-community",
+            visibility="public",
+            source_exposure="public",
+            repository_role="projection",
+            distribution_mode="source",
+            canonicalRepository="hackelia-micrantha/keylix",
+            implementationAuthority="hackelia-micrantha/keylix",
+            releaseAuthority="hackelia-micrantha/keylix",
+        )
+
+        self.assertEqual(
+            source_posture.validate_registry_posture(
+                self.registry(canonical, projection)
+            ),
+            [],
+        )
+
+    def test_calathea_public_canonical_core_and_private_composition_are_valid(self) -> None:
+        public_core = self.entry(
+            "hackelia-micrantha/calathea-community",
+            visibility="public",
+            source_exposure="public",
+            repository_role="canonical",
+            distribution_mode="source",
+            implementationAuthority="hackelia-micrantha/calathea-community",
+            releaseAuthority="hackelia-micrantha/calathea-community",
+        )
+        private_composition = self.entry(
+            "hackelia-micrantha/calathea",
+            visibility="private",
+            source_exposure="private",
+            repository_role="internal",
+            distribution_mode="internal",
+            implementationAuthority="hackelia-micrantha/calathea",
+            releaseAuthority="hackelia-micrantha/calathea",
+        )
+
+        self.assertEqual(
+            source_posture.validate_registry_posture(
+                self.registry(public_core, private_composition)
+            ),
+            [],
+        )
+
+    def test_partial_posture_is_rejected(self) -> None:
+        data = self.registry(
+            self.entry(
+                "hackelia-micrantha/example",
+                visibility="public",
+                source_exposure="public",
+            )
+        )
+
+        errors = source_posture.validate_registry_posture(data)
+
+        self.assertTrue(any("posture is partial" in error for error in errors))
+
+    def test_source_distribution_requires_public_source_exposure(self) -> None:
+        data = self.registry(
+            self.entry(
+                "hackelia-micrantha/example",
+                visibility="public",
+                source_exposure="none",
+                repository_role="distribution",
+                distribution_mode="source",
+            )
+        )
+
+        errors = source_posture.validate_registry_posture(data)
+
+        self.assertTrue(any("distributes source" in error for error in errors))
+
+    def test_public_repository_cannot_claim_private_source_exposure(self) -> None:
+        data = self.registry(
+            self.entry(
+                "hackelia-micrantha/example",
+                visibility="public",
+                source_exposure="private",
+                repository_role="canonical",
+                distribution_mode="binary",
+            )
+        )
+
+        errors = source_posture.validate_registry_posture(data)
+
+        self.assertTrue(any("is public but declares private source exposure" in error for error in errors))
+
+    def test_repository_references_must_resolve(self) -> None:
+        data = self.registry(
+            self.entry(
+                "hackelia-micrantha/example-community",
+                visibility="public",
+                source_exposure="none",
+                repository_role="distribution",
+                distribution_mode="binary",
+                canonicalRepository="hackelia-micrantha/missing",
+            )
+        )
+
+        errors = source_posture.validate_registry_posture(data)
+
+        self.assertTrue(any("references unregistered repository" in error for error in errors))
+
+    def test_public_distribution_reference_must_be_public(self) -> None:
+        canonical = self.entry(
+            "hackelia-micrantha/example",
+            visibility="private",
+            source_exposure="private",
+            repository_role="canonical",
+            distribution_mode="binary",
+            publicDistributionRepository="hackelia-micrantha/internal-dist",
+        )
+        distribution = self.entry(
+            "hackelia-micrantha/internal-dist",
+            visibility="private",
+            source_exposure="private",
+            repository_role="distribution",
+            distribution_mode="binary",
+        )
+
+        errors = source_posture.validate_registry_posture(
+            self.registry(canonical, distribution)
+        )
+
+        self.assertTrue(any("must reference a public repository" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/source_posture.py
+++ b/tools/source_posture.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Validate Micrantha source-exposure and repository-distribution posture.
+
+This validator is intentionally incremental: repositories without posture metadata are
+accepted while the organization rollout proceeds. Once any primary posture field is
+present, the complete primary triple is required and mechanically contradictory
+combinations fail closed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+SOURCE_EXPOSURES = {"public", "private", "none"}
+REPOSITORY_ROLES = {"canonical", "distribution", "projection", "mirror", "internal", "meta"}
+DISTRIBUTION_MODES = {"source", "binary", "package", "closure", "internal", "none"}
+PRIMARY_FIELDS = {"sourceExposure", "repositoryRole", "distributionMode"}
+REFERENCE_FIELDS = {
+    "implementationAuthority",
+    "releaseAuthority",
+    "canonicalRepository",
+    "publicDistributionRepository",
+}
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+def _prefix(index: int, repository: object) -> str:
+    if isinstance(repository, str):
+        return f"repositories[{index}] ({repository})"
+    return f"repositories[{index}]"
+
+
+def validate_repository_posture(
+    item: dict[str, Any],
+    *,
+    index: int,
+    registered: dict[str, dict[str, Any]],
+) -> list[str]:
+    """Return semantic posture errors for one registry entry."""
+
+    errors: list[str] = []
+    repository = item.get("repository")
+    prefix = _prefix(index, repository)
+
+    present_primary = PRIMARY_FIELDS.intersection(item)
+    if not present_primary:
+        # Migration mode: legacy entries remain valid until deliberately classified.
+        return errors
+
+    missing_primary = sorted(PRIMARY_FIELDS - item.keys())
+    if missing_primary:
+        errors.append(
+            f"{prefix} posture is partial; missing: {', '.join(missing_primary)}"
+        )
+        return errors
+
+    source_exposure = item.get("sourceExposure")
+    repository_role = item.get("repositoryRole")
+    distribution_mode = item.get("distributionMode")
+    visibility = item.get("visibility")
+
+    if source_exposure not in SOURCE_EXPOSURES:
+        errors.append(
+            f"{prefix}.sourceExposure must be one of {sorted(SOURCE_EXPOSURES)}"
+        )
+    if repository_role not in REPOSITORY_ROLES:
+        errors.append(
+            f"{prefix}.repositoryRole must be one of {sorted(REPOSITORY_ROLES)}"
+        )
+    if distribution_mode not in DISTRIBUTION_MODES:
+        errors.append(
+            f"{prefix}.distributionMode must be one of {sorted(DISTRIBUTION_MODES)}"
+        )
+
+    if source_exposure == "public" and visibility in {"private", "internal"}:
+        errors.append(
+            f"{prefix} declares public source exposure but repository visibility is {visibility}"
+        )
+    if source_exposure == "private" and visibility == "public":
+        errors.append(
+            f"{prefix} is public but declares private source exposure; use 'none' for a public artifact-only surface or 'public' for an intentional source projection"
+        )
+    if distribution_mode == "source" and source_exposure != "public":
+        errors.append(
+            f"{prefix} distributes source but sourceExposure is {source_exposure!r}"
+        )
+    if repository_role == "distribution" and distribution_mode == "none":
+        errors.append(
+            f"{prefix} has repositoryRole 'distribution' but distributionMode 'none'"
+        )
+
+    for field in sorted(REFERENCE_FIELDS):
+        value = item.get(field)
+        if value is None:
+            continue
+        if not isinstance(value, str) or not REPOSITORY_RE.fullmatch(value):
+            errors.append(f"{prefix}.{field} must be an owner/name repository reference or null")
+            continue
+        target = registered.get(value)
+        if target is None:
+            errors.append(f"{prefix}.{field} references unregistered repository {value}")
+            continue
+        if field == "publicDistributionRepository" and target.get("visibility") != "public":
+            errors.append(
+                f"{prefix}.publicDistributionRepository must reference a public repository: {value}"
+            )
+
+    if isinstance(repository, str):
+        canonical = item.get("canonicalRepository")
+        if repository_role == "canonical" and canonical not in {None, repository}:
+            errors.append(
+                f"{prefix} is canonical but canonicalRepository points to {canonical}"
+            )
+        if repository_role in {"distribution", "projection", "mirror"} and canonical == repository:
+            errors.append(
+                f"{prefix} cannot point canonicalRepository at itself while acting as {repository_role}"
+            )
+        public_distribution = item.get("publicDistributionRepository")
+        if public_distribution == repository:
+            errors.append(f"{prefix}.publicDistributionRepository must not point to itself")
+
+    return errors
+
+
+def validate_registry_posture(data: Any) -> list[str]:
+    """Validate posture metadata for every repository in a registry object."""
+
+    if not isinstance(data, dict):
+        return ["registry root must be an object"]
+    repositories = data.get("repositories")
+    if not isinstance(repositories, list):
+        return ["repositories must be an array"]
+
+    registered: dict[str, dict[str, Any]] = {}
+    for item in repositories:
+        if not isinstance(item, dict):
+            continue
+        repository = item.get("repository")
+        if isinstance(repository, str):
+            registered[repository] = item
+
+    errors: list[str] = []
+    for index, item in enumerate(repositories):
+        if not isinstance(item, dict):
+            continue
+        errors.extend(
+            validate_repository_posture(item, index=index, registered=registered)
+        )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "registry",
+        nargs="?",
+        type=Path,
+        default=Path("metadata/repositories.json"),
+    )
+    args = parser.parse_args()
+
+    try:
+        data = json.loads(args.registry.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"ERROR: file does not exist: {args.registry}", file=sys.stderr)
+        return 2
+    except json.JSONDecodeError as exc:
+        print(
+            f"ERROR: invalid JSON in {args.registry}: line {exc.lineno}, column {exc.colno}: {exc.msg}",
+            file=sys.stderr,
+        )
+        return 2
+
+    errors = validate_registry_posture(data)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    classified = sum(
+        1
+        for item in data.get("repositories", [])
+        if isinstance(item, dict) and PRIMARY_FIELDS.intersection(item)
+    )
+    print(
+        f"Validated source/distribution posture for {classified} classified repositories; unclassified entries remain permitted during rollout"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements the first executable slice of #66 and supports the ecosystem rollout in `hackelia-micrantha/hackelia-micrantha#35`.

## What changes

- extend `metadata/repositories.schema.json` with orthogonal source-exposure, repository-role, authority-edge, and distribution-mode fields;
- keep posture metadata optional during migration, but require the primary exposure/role/distribution triple once classification begins;
- add dependency-free semantic validation in `tools/source_posture.py`;
- fail closed on mechanically contradictory states such as source distribution with no public source exposure, unresolved repository authority edges, and public repositories claiming private implementation exposure;
- add tests covering four distinct topology classes: legacy/unclassified migration, Invokrum private-canonical/public-binary distribution, Keylix private-canonical/public-source projection, and Calathea public canonical core/private composition;
- wire posture validation into `mise validate` and meta-validation CI;
- add a non-normative architecture guide that maps source exposure to Nix/package choices without duplicating the normative source/release/CLI standards.

## Migration behavior

This intentionally does **not** make the new fields universally required yet. Existing registry entries remain valid until deliberately classified through #35. Once any primary posture field is present, the complete primary triple is required and semantic contradictions fail validation.

## Security / governance boundary

- repository names and GitHub visibility do not grant implementation or release authority;
- `-community` is not treated as a topology type;
- public binary distribution does not require exporting private implementation source;
- public source projection remains representable without making the projection canonical;
- package/signature validity remains evidence, not runtime/governance authority.

## Follow-up after this slice

- classify the real registry entries incrementally, starting with Invokrum, Keylix, Calathea, Anthesis, Sandcastle, and active package/release projects;
- integrate posture into repository-health reporting rather than only validation;
- add release-readiness checks for package/source contradictions and release identity drift.

Closes no rollout issue by itself; #66 remains open until migration/reporting/readiness criteria are complete.