### PR TITLE
Add reusable Micrantha engineering skills

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,40 @@
+# Micrantha engineering skills
+
+Micrantha skills are reusable, bounded orchestration contracts for recurring engineering work. A skill defines **when to run**, **what evidence to inspect**, **which existing prompts and standards govern the work**, **what mutations are permitted**, and **what completion means**.
+
+Skills do not replace prompts, standards, templates, or project-local authority. They compose those sources into an executable workflow.
+
+## Contract
+
+Each skill uses `SKILL.md` and should define:
+
+- **Trigger** — recognizable operator intent and situations where the skill applies;
+- **Inputs** — minimum context and authority required;
+- **Workflow** — ordered evidence-backed actions;
+- **Evidence** — what must be inspected or produced;
+- **Mutation boundary** — read-only by default unless the invocation authorizes writes;
+- **Completion** — a falsifiable stop condition;
+- **References** — canonical Micrantha prompts, standards, templates, or project-local sources.
+
+A skill may invoke another skill. Composition must preserve the stricter authority, security, evidence, and completion requirements of every invoked skill.
+
+## Initial skill set
+
+| Skill | Purpose |
+| --- | --- |
+| [`project-review`](project-review/SKILL.md) | Broad repository/project reconciliation |
+| [`project-triage`](project-triage/SKILL.md) | Convert reviewed state into a prioritized executable queue |
+| [`issue-grooming`](issue-grooming/SKILL.md) | Produce bounded, verifiable work items |
+| [`qart-analysis`](qart-analysis/SKILL.md) | Resolve a bounded decision through Questions, Alternatives, Recommendation, Trade-offs |
+| [`implementation-plan`](implementation-plan/SKILL.md) | Turn accepted intent into ordered, independently verifiable slices |
+| [`pr-review`](pr-review/SKILL.md) | Review a change set for correctness, risk, scope, and evidence |
+| [`merge-readiness`](merge-readiness/SKILL.md) | Decide merge/fix/block/close from exact-head evidence |
+| [`test-strategy`](test-strategy/SKILL.md) | Design risk-based layered validation and Testule integration |
+| [`security-review`](security-review/SKILL.md) | Review trust boundaries, abuse paths, privileges, and safe failure |
+| [`release-integration`](release-integration/SKILL.md) | Apply Micrantha release/distribution/integration strategy across repositories |
+
+## Execution rules
+
+The shared execution, ambiguity, validation, and priority contracts in [`docs/prompts/README.md`](../docs/prompts/README.md) apply to every skill unless a skill explicitly tightens them.
+
+Prefer durable mechanical controls over adding more prompt prose. When a recurring lesson can be enforced by a test, schema, type, CI gate, packaging check, capability boundary, or safer tool behavior, create or recommend that mechanism rather than relying on operator memory.

--- a/skills/implementation-plan/SKILL.md
+++ b/skills/implementation-plan/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: implementation-plan
+description: Convert accepted intent, a groomed issue, RFC, ADR, or epic into ordered, independently verifiable implementation slices.
+---
+
+# Implementation plan
+
+## Trigger
+
+Use for `make a plan`, `proceed`, `break this down`, or when accepted work is too broad to implement safely in one change.
+
+## Inputs
+
+- authoritative issue/spec/RFC/ADR or equivalent accepted intent;
+- current implementation and dependency graph;
+- release, compatibility, security, and migration constraints.
+
+## Workflow
+
+1. Reconfirm the accepted outcome and separate unresolved decisions from implementation work.
+2. Identify contracts/boundaries that must remain stable while work is in progress.
+3. Slice vertically where possible so each step produces independently reviewable evidence.
+4. Order slices by dependency and risk: establish contracts/invariants first, then implementation, integration, migration, and cleanup.
+5. Include tests, static analysis, documentation, packaging, migration, rollback, and operational changes in the slice that creates the obligation rather than deferring them to a generic cleanup phase.
+6. Identify parallel-safe work and work that must remain serialized.
+7. Define per-slice acceptance evidence and the condition for moving to the next slice.
+8. Route newly discovered architectural alternatives back to `qart-analysis` rather than burying a decision in implementation detail.
+
+## Evidence
+
+The plan should map each slice to an accepted requirement, decision, risk, or dependency and name the validation that proves it complete.
+
+## Completion
+
+Complete when the first slice can start immediately, later slices have explicit dependency edges, and the overall plan reaches the accepted outcome without relying on an undefined final integration step.
+
+## References
+
+- `docs/prompts/planning/classify-and-route.md`
+- `docs/prompts/planning/next-executable-slice.md`
+- `docs/prompts/pull-requests/large-change-decomposition.md`
+- `docs/engineering/work-items.md`

--- a/skills/issue-grooming/SKILL.md
+++ b/skills/issue-grooming/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: issue-grooming
+description: Turn a finding, request, or rough issue into a bounded engineering work item with observable outcome, scope, acceptance criteria, dependencies, and validation.
+---
+
+# Issue grooming
+
+## Trigger
+
+Use for `groom this issue`, `make an issue`, `update issues`, or whenever an executable backlog item lacks a falsifiable outcome or clear verification.
+
+## Inputs
+
+- problem/finding and affected repository boundary;
+- authoritative requirements or design evidence;
+- known dependencies/blockers and current implementation evidence.
+
+## Workflow
+
+1. Verify that an issue is the right artifact; route unresolved alternatives to QART, broad proposals to RFC, unknown feasibility to a spike, and accepted decisions to ADR where appropriate.
+2. State the user/operator/system outcome rather than implementation activity alone.
+3. Bound in-scope and out-of-scope work.
+4. Add acceptance criteria that can be objectively verified.
+5. Identify dependencies, blockers, compatibility/security implications, and required docs.
+6. Define the smallest trustworthy validation layers and exact evidence expected.
+7. Assign priority from current impact and dependency value rather than age.
+8. Avoid combining unrelated outcomes merely to reduce issue count; avoid one issue per observation when one coherent outcome covers them.
+
+## Evidence
+
+The issue should link or name the evidence that motivated it and identify assumptions that remain unverified.
+
+## Completion
+
+Complete when an implementer can start the issue without rediscovering intent, scope, authority, dependencies, or the definition of done.
+
+## References
+
+- `docs/prompts/issues/issue-grooming.md`
+- `docs/prompts/planning/classify-and-route.md`
+- `docs/engineering/work-items.md`
+- `.github/ISSUE_TEMPLATE/delivery-slice.md`

--- a/skills/merge-readiness/SKILL.md
+++ b/skills/merge-readiness/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: merge-readiness
+description: Decide whether a pull request is safe to merge using exact-head review, CI, test, dependency, and integration evidence.
+---
+
+# Merge readiness
+
+## Trigger
+
+Use for `review to fix or merge`, `is this green PR mergeable?`, or after `pr-review` has established the substantive findings.
+
+## Inputs
+
+- exact PR head SHA and current base branch state;
+- review findings and unresolved threads;
+- required checks/workflow runs for the exact head;
+- linked acceptance criteria and dependency/blocker state.
+
+## Workflow
+
+1. Confirm the reviewed head SHA is still current and the base has not introduced a material conflict or semantic regression.
+2. Confirm all merge-blocking review findings are resolved or explicitly dispositioned.
+3. Verify required checks are present, completed, non-stale, correctly scoped, and tied to the exact head revision.
+4. Treat skipped, cancelled, flaky, missing, neutralized, or unrelated checks as evidence gaps rather than success.
+5. Verify applicable unit/component, contract, integration, end-to-end, security, migration, packaging, and static-analysis evidence according to risk.
+6. Re-evaluate dependency edges and whether another pending change must land first.
+7. Choose exactly one disposition: `merge`, `fix`, `block`, or `close`, and state the minimum evidence/change required for any non-merge disposition.
+8. Merge only when mutation authority is explicit; use expected-head protection where supported.
+
+## Completion
+
+Complete when there is a concrete disposition grounded in the exact current head and no material ambiguity remains about why the PR can or cannot merge.
+
+## References
+
+- `docs/prompts/pull-requests/merge-gate-review.md`
+- `docs/prompts/ci/ci-failure-triage.md`
+- `docs/standards/testing.md`
+- `docs/standards/ci-cd.md`

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: pr-review
+description: Review a pull request or bounded change set for correctness, architecture, security, scope, regressions, validation, and alignment with its authoritative work item.
+---
+
+# Pull request review
+
+## Trigger
+
+Use for `review PR`, `review this change`, or before a merge-readiness decision when the code/diff itself has not yet been critically reviewed.
+
+## Inputs
+
+- exact PR head/diff and current base;
+- linked issue/spec/RFC/ADR and acceptance criteria;
+- CI/test evidence, review threads, and relevant project-local standards.
+
+## Workflow
+
+1. Establish the intended outcome and review the actual diff, not only the PR description.
+2. Check correctness, error handling, concurrency/state behavior, data handling, compatibility, and failure paths relevant to the change.
+3. Review architecture and ownership boundaries; flag unnecessary coupling, duplication, or hidden policy decisions.
+4. Review security: untrusted input, authorization, secrets, privilege, process/environment boundaries, supply-chain impact, and safe failure.
+5. Verify tests and static analysis cover changed behavior at the smallest trustworthy layers; distinguish exact-head evidence from stale or unrelated runs.
+6. Check migrations, docs, packaging, observability, operational impact, and rollback where applicable.
+7. Reconcile unresolved review threads and identify scope that should be split rather than accepted as review debt.
+8. Produce findings ordered by severity/merge impact with concrete evidence and remediation.
+
+## Mutation boundary
+
+Read-only by default. Do not push fixes, resolve threads, modify labels, or merge unless explicitly authorized.
+
+## Completion
+
+Complete when all material findings are explicit and the change is ready to hand to `merge-readiness` for a merge/fix/block/close decision.
+
+## References
+
+- `docs/prompts/pull-requests/merge-gate-review.md`
+- `docs/prompts/reviews/engineering-artifact-review.md`
+- `docs/standards/testing.md`
+- `docs/standards/ci-cd.md`
+- `docs/standards/security.md`

--- a/skills/project-review/SKILL.md
+++ b/skills/project-review/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: project-review
+description: Reconcile a Micrantha project against implementation, architecture, security, testing, backlog, documentation, maturity, and current evidence.
+---
+
+# Project review
+
+## Trigger
+
+Use for requests such as `review the project`, `review this repo`, `assess current state`, or when a repository needs a trustworthy baseline before planning or mutation.
+
+## Inputs
+
+- repository/project identity and accessible evidence;
+- current branch/default branch and relevant open issues/PRs;
+- project-local architecture, requirements, ADRs/RFCs, tests, CI, release and security evidence;
+- explicit mutation authority if the operator wants findings applied.
+
+## Workflow
+
+1. Establish project purpose, maturity, supported contracts, repository role, and authoritative sources.
+2. Reconcile implementation against issues, PRs, docs, decisions, CI, tests, releases, and public claims.
+3. Inspect architecture, boundaries, duplication, complexity, modernization, performance, security, operability, UX where applicable, and maintainability.
+4. Assess validation using the organization testing and CI/CD standards; distinguish exact evidence from assumptions or stale green checks.
+5. Identify completed work, incomplete work, gaps, contradictions, overlap, stale artifacts, and opportunities.
+6. Classify findings by impact and confidence; do not create one action per observation.
+7. If writes are authorized, route material findings through `project-triage` and apply only bounded reconciliations.
+
+## Evidence
+
+Report verified facts separately from inference. Record evidence that could not be inspected. Prefer current default-branch/project-local evidence over copied summaries.
+
+## Completion
+
+Complete when the project has an evidence-backed current-state model, material discrepancies are explicit, and the next decision or executable work can be selected without repeating the broad review.
+
+## References
+
+- `docs/prompts/project-review/comprehensive-status-review.md`
+- `docs/prompts/project-review/status-refresh.md`
+- `docs/prompts/reviews/engineering-artifact-review.md`
+- `docs/standards/testing.md`
+- `docs/standards/ci-cd.md`

--- a/skills/project-triage/SKILL.md
+++ b/skills/project-triage/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: project-triage
+description: Convert a reviewed project state into a prioritized, dependency-aware, executable work queue and reconcile stale or overlapping work.
+---
+
+# Project triage
+
+## Trigger
+
+Use after `project-review`, for `triage issues`, `what is next?`, `update issues`, or when the backlog no longer represents the actual implementation state.
+
+## Inputs
+
+- a recent project review or equivalent trustworthy baseline;
+- open issues, PRs, milestones/epics, accepted decisions, and blockers;
+- current release/milestone goals and explicit mutation authority for backlog changes.
+
+## Workflow
+
+1. Reconcile open work against implementation and merged history.
+2. Close or recommend closing work that is completed, duplicate, superseded, invalid, or no longer aligned.
+3. Merge overlapping findings into the smallest coherent set of outcomes.
+4. Preserve distinction among priority, severity, status, confidence, and size.
+5. Identify dependency edges and blockers; prefer work that unlocks the current milestone or multiple downstream items.
+6. Ensure P1 is a small next-up queue rather than a second backlog.
+7. Route ambiguous work to the minimum responsible artifact: issue, spike, QART, RFC, ADR, security review, or epic.
+8. Run `issue-grooming` on executable items and `implementation-plan` where sequencing is non-trivial.
+
+## Evidence
+
+Every priority or closure decision should cite current implementation, accepted decision, dependency, failure evidence, or milestone need rather than age or intuition alone.
+
+## Completion
+
+Complete when the backlog reflects reality, blockers and dependency edges are explicit, and at least one next executable slice can begin without additional broad triage.
+
+## References
+
+- `docs/prompts/planning/classify-and-route.md`
+- `docs/prompts/planning/next-executable-slice.md`
+- `docs/prompts/issues/issue-grooming.md`
+- `docs/prompts/project-review/status-refresh.md`
+- `CONTRIBUTING.md`

--- a/skills/qart-analysis/SKILL.md
+++ b/skills/qart-analysis/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: qart-analysis
+description: Resolve one bounded decision through Questions, Alternatives, Recommendation, and Trade-offs before promoting the decision to an ADR or broader RFC.
+---
+
+# QART analysis
+
+## Trigger
+
+Use when a consequential choice has real alternatives, unresolved assumptions, or trade-offs that should be explicit before implementation.
+
+## Inputs
+
+- one bounded decision question;
+- constraints, non-goals, current architecture, and affected contracts;
+- available implementation/research evidence and decision owner where known.
+
+## Workflow
+
+1. Frame one decision narrowly enough that a recommendation can actually be made.
+2. Enumerate material questions and unknowns; resolve cheap factual questions before comparing alternatives.
+3. Identify viable alternatives including status quo when it is genuinely viable.
+4. Compare alternatives against explicit criteria: correctness, security, maintainability, operability, compatibility, cost, reversibility, complexity, and project-specific concerns.
+5. Recommend an option only when evidence supports it; otherwise state what evidence is required next.
+6. Record trade-offs, rejected alternatives, migration/rollback implications, and residual uncertainty.
+7. Promote to an ADR when the decision is accepted; use an RFC first when broad review or cross-boundary coordination remains necessary.
+
+## Evidence
+
+Distinguish measured/verified constraints from assumptions and preferences. Link material evidence rather than restating it as fact without provenance.
+
+## Completion
+
+Complete when the bounded question has either an evidence-backed recommendation ready for disposition or a precisely defined investigation that blocks the decision.
+
+## References
+
+- `docs/prompts/decisions/qart-analysis.md`
+- `docs/prompts/decisions/qart-to-adr.md`
+- `docs/prompts/decisions/rfc-development.md`
+- `docs/engineering/templates/qart.md`

--- a/skills/release-integration/SKILL.md
+++ b/skills/release-integration/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: release-integration
+description: Apply the Micrantha release, source-exposure, public distribution, Nix flake, and downstream integration strategy across project repositories.
+---
+
+# Release integration
+
+## Trigger
+
+Use for `make a release`, `include this in Dubnium/dotfiles`, `apply Micrantha release/integration strategy`, or when a project must move from canonical implementation to a consumable pinned downstream package.
+
+## Inputs
+
+- canonical repository and authorized release revision;
+- source-exposure topology (public source or private canonical + public distribution);
+- build/package commands, versioning, supported platforms, CLI/man-page contracts;
+- public/community distribution repository where applicable;
+- downstream consumers such as Dubnium/dotfiles and their lock/update mechanism.
+
+## Workflow
+
+1. Establish release authority, exact canonical revision, version, and source-exposure boundary.
+2. Require exact-head build/test/static-analysis evidence and release-readiness review before publication.
+3. Build the release artifact from the canonical repository and validate the **artifact contents**, permissions, version identity, executable smoke path, and required documentation.
+4. For private implementation, ensure the public distribution surface receives immutable artifacts/contracts/metadata—not buildable private source or internal-only material.
+5. Publish checksums/signatures/provenance/SBOM as required by project and organization policy.
+6. For CLI tools, include the executable and section-1 man page in conventional paths and verify both after installation.
+7. Maintain a public Nix flake that fetches an immutable versioned artifact and pins its cryptographic hash when private-source distribution is intentional. Do not use a source-building public flake for private implementation.
+8. Update downstream consumers through committed version/flake lock state; do not point production/system configuration at floating branches or mutable artifacts.
+9. Validate the downstream installed command, version, man page, and critical integration path on the actual consumer environment/CI.
+10. Record rollback/update instructions and reconcile release notes, public docs, issues, and project status.
+
+## Security boundary
+
+Private source is not a substitute for secure design. Assume distributed binaries can be reverse engineered; never ship secrets or controls that depend on client-side secrecy. Treat the public/community repository as a distribution trust boundary with minimum necessary contents.
+
+## Completion
+
+Complete when the exact authorized revision is represented by an immutable verified release, the distribution surface exposes the intended consumer contract, downstream consumers pin that release, and installed-path validation succeeds with rollback understood.
+
+## References
+
+- `docs/standards/source-exposure-and-distribution.md`
+- `docs/standards/releases.md`
+- `docs/standards/cli-interoperability.md`
+- `docs/standards/ci-cd.md`
+- `docs/prompts/releases/release-readiness.md`
+- `docs/architecture/repository-topology-and-trust-domains.md`

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: security-review
+description: Review a Micrantha change, capability, or system for assets, trust boundaries, abuse paths, privileges, untrusted input, secret exposure, supply-chain risk, and safe failure.
+---
+
+# Security review
+
+## Trigger
+
+Use for `security review`, `threat review`, `review this boundary`, or whenever a change affects authentication, authorization, secrets, external input, execution, agents/tools, release pipelines, or cross-repository trust.
+
+## Inputs
+
+- architecture/data-flow and affected trust boundaries;
+- actor identities, capabilities, credentials, and authority sources;
+- untrusted inputs, external dependencies, execution environments, and persistence;
+- relevant security requirements and project-local threat model/evidence.
+
+## Workflow
+
+1. Identify assets, actors, trust boundaries, entry points, and authoritative security properties.
+2. Trace untrusted data and control flow across parsing, storage, network, process, plugin/tool, and repository/release boundaries.
+3. Review authentication, authorization, least privilege, ambient authority, capability delegation, revocation, stale authority, and approval semantics.
+4. Check secret handling and process/environment inheritance; require bounded environments where subprocesses do not need ambient credentials.
+5. Review injection, path/file handling, unsafe deserialization, race/state transitions, replay/idempotency, denial behavior, and error information exposure where relevant.
+6. Review dependency, build, provenance, artifact, and publication trust for supply-chain changes.
+7. For agentic systems, inspect tool identity, policy enforcement, approval/evidence/provenance, bypass resistance, and distinction between advisory memory/context and effect authority.
+8. Require tests of protected invariants and denial paths, not only successful authorization.
+9. Rank findings by exploitability/impact and identify the weakest durable control that prevents recurrence.
+
+## Mutation boundary
+
+Do not reproduce secret values. Report location/type/exposure path and remediation. Read-only unless fixes are explicitly authorized.
+
+## Completion
+
+Complete when material trust boundaries and abuse paths are accounted for, residual risks are explicit, and each actionable finding has a concrete control and validation expectation.
+
+## References
+
+- `docs/standards/security.md`
+- `docs/standards/ci-cd.md`
+- `docs/standards/source-exposure-and-distribution.md`
+- `docs/prompts/security/agentic-workflow-security-review.md`
+- `docs/prompts/reviews/compound-review.md`

--- a/skills/test-strategy/SKILL.md
+++ b/skills/test-strategy/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: test-strategy
+description: Design a risk-based layered validation strategy for a Micrantha project or capability, including Testule where it strengthens deterministic execution and evidence.
+---
+
+# Test strategy
+
+## Trigger
+
+Use for `define the test strategy`, `review test gaps`, `prepare tests before implementation/release`, or when a project has ad-hoc tests without an explicit validation model.
+
+## Inputs
+
+- project/capability contracts and supported user/operator outcomes;
+- architecture and integration boundaries;
+- material security, migration, compatibility, performance, and operational risks;
+- current test suites, tooling, CI gates, and Testule capability where applicable.
+
+## Workflow
+
+1. Map requirements and safety properties to failure modes and observable evidence.
+2. Build a project-appropriate test pyramid/layer model rather than mechanically requiring every layer.
+3. Put deterministic local behavior at unit/component level; protect public schemas/commands/formats with contract tests; exercise owned real boundaries with integration tests; keep end-to-end coverage focused on critical supported paths.
+4. Add negative/security, migration/rollback, compatibility, performance/capacity, and operational exercises only where concrete risk warrants them.
+5. Identify escaped-defect and boundary gaps; require bug fixes to add regression coverage at the lowest trustworthy layer and strengthen the layer that should have caught the escape.
+6. Define fixtures, isolation, determinism, external-dependency policy, flake handling, and test-data security.
+7. Integrate Testule where it can provide reusable test orchestration, fixtures, conformance, evidence capture, or failure injection without making projects depend on unnecessary central runtime authority.
+8. Ensure local canonical commands and CI gates exercise equivalent validation; distinguish required gates from advisory diagnostics.
+9. Define release validation against the packaged/installed artifact, not only the source tree.
+
+## Evidence
+
+Produce a requirements/risk-to-test map, layer ownership, canonical commands/gates, known gaps, and explicit rationale for omitted layers.
+
+## Completion
+
+Complete when material requirements and risks have a named trustworthy validation mechanism, gaps are explicit and prioritized, and CI/release evidence can prove what actually ran.
+
+## References
+
+- `docs/standards/testing.md`
+- `docs/standards/ci-cd.md`
+- `docs/prompts/README.md` shared validation contract
+- Testule project-local contracts and documentation when integration is proposed


### PR DESCRIPTION
## Outcome

Introduce a first-class `skills/` layer for recurring Micrantha engineering workflows.

Skills are thin orchestration contracts over existing prompts, standards, templates, and project-local authority. Each defines trigger, inputs, workflow, evidence, mutation boundary where material, completion, and canonical references.

## Initial skills

- project-review
- project-triage
- issue-grooming
- qart-analysis
- implementation-plan
- pr-review
- merge-readiness
- test-strategy
- security-review
- release-integration

## Design boundary

This repository remains authoritative for organization-wide reusable engineering behavior. The Micrantha meta repository will catalogue and compose these skills at ecosystem level without duplicating their definitions.

## Notable additions

- `test-strategy` encodes risk-based layered validation and optional Testule integration.
- `release-integration` captures canonical revision → validated artifact → public/community distribution where applicable → immutable package/flake → pinned downstream consumer → installed-path validation.
- merge readiness explicitly requires exact-head evidence rather than ambient/stale green CI.

## Validation

Documentation-only change. Review should verify links/paths, consistency with existing prompt/standard ownership, and that skill contracts do not create new authority beyond their referenced sources.