### PR TITLE
Clarify project-local skills and risk-adaptive model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Micrantha organization defaults
 
-This repository contains shared governance, community health files, contribution conventions, issue and pull-request templates, engineering prompts, standards, automation, and reusable guidance for repositories in the `hackelia-micrantha` organization.
+This repository contains shared governance, community health files, contribution conventions, issue and pull-request templates, engineering prompts, standards, automation, shared skill defaults, and reusable guidance for repositories in the `hackelia-micrantha` organization.
 
 Repositories may refine these defaults when their product, legal, security, or operating model requires it, but should document the difference explicitly. Repository-local implementation and evidence remain authoritative within the boundaries assigned by the organization governance model.
 
@@ -11,11 +11,13 @@ Use the repository that owns the question:
 | Question | Source of truth |
 | --- | --- |
 | How should Micrantha repositories be governed and engineered? | This repository (`hackelia-micrantha/.github`) |
+| What shared skill defaults are available? | [`skills/`](skills/) in this repository |
+| What operational skills does a specific project use? | The owning project repository |
 | What Micrantha projects exist, what are their roles/lifecycles, and how do they relate? | [`hackelia-micrantha/hackelia-micrantha`](https://github.com/hackelia-micrantha/hackelia-micrantha) |
 | What does a specific product/library/tool implement? | The owning project repository |
 | What is presented publicly? | [`micrantha.com`](https://micrantha.com) and [`profile/README.md`](profile/README.md), as evidence-backed projections |
 
-The meta/registry repository coordinates ecosystem identity and relationships; it does not own organization GitHub policy. This repository defines shared defaults and responsibility boundaries; it does not become a second implementation source of truth for projects.
+The meta/registry repository coordinates ecosystem identity, relationships, and skill discovery/composition; it does not own organization GitHub policy or project-local operational skills. This repository defines shared defaults and responsibility boundaries; it does not become a second implementation source of truth for projects.
 
 ## Governance and ownership
 
@@ -74,8 +76,10 @@ The repository registry is an advisory machine-readable projection of the canoni
   - [QART template](docs/engineering/templates/qart.md)
   - [RFC template](docs/engineering/templates/rfc.md)
   - [ADR template](docs/engineering/templates/adr.md)
+- [Shared engineering skills](skills/README.md) — reusable defaults/reference contracts; operational skills remain project-local by default
 - [Compound engineering](docs/engineering/compound-engineering.md) — Plan → Work → Review → Compound → Repeat
 - [AI-assisted SDLC phase discipline](docs/engineering/ai-assisted-sdlc.md) — explicit phase-local context, durable handoffs, verification, review, and authority boundaries
+- [AI model selection and escalation](docs/engineering/ai-model-selection.md) — risk-adaptive model choice; frontier inference is an escalation option rather than a universal requirement
 - [Compound artifact routing](docs/engineering/compound-artifact-routing.md) — route reusable lessons to the weakest durable control that reliably prevents recurrence
 - [Governed learning promotion](docs/architecture/governed-learning-promotion.md) — candidate learning, validation, exact promotion, supersession, and authority boundaries
 - [Compound learning runtime boundaries](docs/architecture/compound-learning-runtime.md) — Supervisor, Run Ledger, Memory, Invokrum, Sandcastle, Anthesis, and scheduler ownership

--- a/docs/engineering/ai-model-selection.md
+++ b/docs/engineering/ai-model-selection.md
@@ -1,0 +1,109 @@
+# AI model selection and escalation
+
+Micrantha selects models according to the bounded task, project maturity, consequence, available verification, privacy constraints, and operational cost. Model tier is an implementation choice unless a project-local or governing policy explicitly makes it part of a tested contract.
+
+The default rule is:
+
+> Use the least expensive and least externally dependent model path that can reliably satisfy the task's reasoning requirements under the required evidence and authority controls; escalate when evidence shows that path is insufficient.
+
+This guidance complements [AI-assisted SDLC phase discipline](./ai-assisted-sdlc.md). It does not change execution authority, review, verification, approval, or release requirements.
+
+## Frontier models are not a universal requirement
+
+Micrantha does **not** require a frontier model merely because a task uses AI, invokes a skill, or participates in an agentic workflow.
+
+Experimental, exploratory, low-consequence, easily reversible, or strongly deterministic work can intentionally use local or smaller models when that is sufficient. Examples include:
+
+- prototype/refactoring experiments isolated from canonical state;
+- bounded repository classification or metadata generation with deterministic validation;
+- candidate plans or QART alternatives that remain proposals until reviewed;
+- test generation where native tests/compilers establish the result;
+- local development workflows where privacy, latency, offline use, or cost materially favors a local model;
+- conformance experiments whose purpose includes measuring model limitations.
+
+An Experimental repository lifecycle is a useful signal that cheaper/local experimentation may be appropriate, but lifecycle alone does not waive security or authority controls. Experimental code can still touch secrets, privileged infrastructure, security boundaries, or irreversible external effects.
+
+## Escalation criteria
+
+Escalate to a stronger model, including a frontier model when appropriate, when one or more of these are material:
+
+- the task requires broad synthesis across a large or unfamiliar system;
+- architecture, security, migration, policy, or compatibility reasoning has substantial consequence;
+- requirements are materially ambiguous and the current model repeatedly fails to resolve them from available evidence;
+- implementation/review cycles repeat without meaningful progress;
+- the candidate contains subtle concurrency, state, language/runtime, cryptographic, or distributed-system behavior that exceeds the current model's demonstrated capability;
+- deterministic checks cannot decide the relevant semantic property and stronger semantic review is justified;
+- the project explicitly defines a minimum model capability/profile for the workflow;
+- a controlled comparison against a stronger model is part of evaluation or conformance evidence.
+
+Escalation is a reasoning-quality decision. It must not silently widen filesystem, network, credential, tool, repository, deployment, or approval authority.
+
+## Evidence beats model prestige
+
+A more capable model can reduce reasoning error but does not establish correctness by identity or reputation.
+
+Prefer this evidence order where applicable:
+
+1. schema, type, integrity, and exact-subject checks;
+2. compiler/static analysis and deterministic tests;
+3. property, invariant, contract, integration, security, migration, and packaging checks appropriate to the boundary;
+4. exact diff/artifact inspection;
+5. independent semantic verification when deterministic evidence cannot establish the property;
+6. human judgment or explicit approval when consequence, policy, or uncertainty requires it.
+
+A deterministic failing check is stronger negative evidence than a frontier model saying the candidate looks correct.
+
+Likewise, a smaller/local model can be entirely adequate when its output is constrained and the decisive properties are externally verifiable.
+
+## Project-local policy
+
+Project repositories own model-selection details for their workflows because the useful trade-offs vary by project.
+
+A project-local skill may declare, when useful:
+
+- a minimum capability/profile rather than a vendor/model name;
+- whether local/offline execution is preferred or required;
+- context-size or multimodal requirements that are intrinsic to the task;
+- an escalation trigger after repeated ambiguity or verification failure;
+- whether a second/independent semantic verifier is required;
+- privacy/data-residency restrictions on external inference;
+- cost/latency ceilings for routine operation;
+- a frontier-model requirement for a specific high-consequence boundary, with rationale.
+
+Avoid hard-coding a model vendor or version unless compatibility with that exact model is itself part of the project's contract or experiment. Model availability and capability change faster than project architecture.
+
+Shared organization skills should therefore describe capability/evidence needs and safe escalation semantics. They are not permission to mandate a single inference provider across the ecosystem.
+
+## Experimental posture
+
+For Experimental work, a useful default is:
+
+```text
+small/local model
+  -> bounded candidate
+  -> deterministic/native verification
+  -> inspect failure evidence
+  -> escalate model only when the reasoning problem warrants it
+```
+
+This keeps experimentation cheap, offline-capable where useful, and informative: a weaker model's failure can itself reveal missing contracts, poor task decomposition, or insufficient deterministic tooling.
+
+Do not compensate for a weaker model by granting broader authority, suppressing failing checks, reducing provenance, or allowing self-approval. If a task cannot be made safe and verifiable with the available model/runtime, stop or escalate the task rather than weakening the controls.
+
+## High-consequence posture
+
+For authentication, authorization, cryptography, permissions, policy, sensitive data, destructive migration, release/deployment controls, public compatibility, or agent authority, use stronger reasoning support when it materially improves review quality—but preserve independent evidence and accountable disposition.
+
+A frontier model may be preferred for difficult reasoning in these domains, but the security property remains in the architecture, runtime enforcement, deterministic verification, independent evidence, and human/governance decision where required—not in the model tier.
+
+## Required invariants
+
+- Model selection is risk- and capability-adaptive, not globally fixed.
+- Frontier-model use is not required by default for Experimental or low-consequence work.
+- Project-local skills own justified model profiles/escalation rules for project-specific workflows.
+- Model tier does not create authority or establish correctness.
+- Escalation cannot widen execution authority automatically.
+- Deterministic evidence is preferred when it can decide the property.
+- Independent verification means independence of the relevant trust roots, not merely a different model name.
+- Privacy, data residency, availability, cost, and offline operation are legitimate model-selection constraints.
+- A weaker model never justifies weaker safety, provenance, review, or verification controls.

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,6 +4,26 @@ Micrantha skills are reusable, bounded orchestration contracts for recurring eng
 
 Skills do not replace prompts, standards, templates, or project-local authority. They compose those sources into an executable workflow.
 
+## Ownership and adoption
+
+**Operational skills are project-local by default.** A project repository owns the skills that encode its actual workflows, tools, architecture, maturity, release path, security boundaries, and completion rules.
+
+The skills in this repository are **organization-wide defaults and reusable reference contracts**. They provide common vocabulary and a starting point for repeated engineering workflows, but they are not implicitly installed, enabled, or mandatory in every Micrantha project.
+
+A project may:
+
+- adopt a shared skill unchanged when it accurately represents the project;
+- specialize a shared skill with project-local inputs, tooling, evidence, or tighter invariants;
+- compose several shared skills into a project-specific workflow;
+- define a project-only skill when the workflow is not meaningfully reusable elsewhere;
+- omit a shared skill that does not apply to the project's maturity, architecture, or operating model.
+
+Project-local skills must not silently weaken organization security, governance, release, or compatibility standards that apply to the project. Conversely, organization defaults must not override repository-local implementation truth or invent project requirements.
+
+When a local skill derives materially from a shared default, prefer recording the source skill and revision/version so drift can be reviewed deliberately rather than inherited accidentally.
+
+The Micrantha meta repository may catalogue shared and project-local skills and compose ecosystem workflows. That catalog is coordination metadata, not the source of truth for a project's operational behavior.
+
 ## Contract
 
 Each skill uses `SKILL.md` and should define:
@@ -18,7 +38,26 @@ Each skill uses `SKILL.md` and should define:
 
 A skill may invoke another skill. Composition must preserve the stricter authority, security, evidence, and completion requirements of every invoked skill.
 
-## Initial skill set
+## Model selection
+
+A skill should describe the **reasoning capability and evidence required**, not assume that a frontier model is always necessary.
+
+Use the least expensive/smallest model path that can reliably perform the bounded task under the project's verification and authority controls. In particular, experimental, exploratory, low-consequence, or easily reversible work may intentionally use local or smaller models when their limitations are acceptable and deterministic validation provides the required evidence.
+
+Escalate to a stronger or frontier model when the task materially benefits from it, for example because of:
+
+- broad or difficult repository/system synthesis;
+- consequential architectural or security reasoning;
+- material ambiguity that a weaker model repeatedly fails to resolve;
+- repeated implementation/review failure without progress;
+- semantic verification that cannot be decided adequately by deterministic checks;
+- project policy that explicitly requires a stronger model class for the affected boundary.
+
+Model class is not a security boundary, source of authority, or proof of correctness. A frontier model does not replace deterministic verification, independent evidence, human disposition where required, or least-privilege execution. A smaller/local model does not justify weakening those controls either.
+
+Project-local skills may declare a justified model capability/profile or escalation rule when useful, but should avoid hard-coding a vendor/model name unless interoperability with that exact model is itself under test.
+
+## Initial shared defaults
 
 | Skill | Purpose |
 | --- | --- |
@@ -35,6 +74,6 @@ A skill may invoke another skill. Composition must preserve the stricter authori
 
 ## Execution rules
 
-The shared execution, ambiguity, validation, and priority contracts in [`docs/prompts/README.md`](../docs/prompts/README.md) apply to every skill unless a skill explicitly tightens them.
+The shared execution, ambiguity, validation, and priority contracts in [`docs/prompts/README.md`](../docs/prompts/README.md) apply to every shared skill unless a skill explicitly tightens them. A project-local skill should reference the organization standards that remain applicable and document intentional project-specific differences.
 
 Prefer durable mechanical controls over adding more prompt prose. When a recurring lesson can be enforced by a test, schema, type, CI gate, packaging check, capability boundary, or safer tool behavior, create or recommend that mechanism rather than relying on operator memory.

--- a/skills/README.md
+++ b/skills/README.md
@@ -57,6 +57,8 @@ Model class is not a security boundary, source of authority, or proof of correct
 
 Project-local skills may declare a justified model capability/profile or escalation rule when useful, but should avoid hard-coding a vendor/model name unless interoperability with that exact model is itself under test.
 
+See [AI model selection and escalation](../docs/engineering/ai-model-selection.md) for the canonical risk-adaptive model-selection policy.
+
 ## Initial shared defaults
 
 | Skill | Purpose |


### PR DESCRIPTION
## Outcome

Clarify that Micrantha operational skills are project-local by default and that organization skills are reusable defaults/reference contracts rather than an implicitly active global skill set.

Also define risk-adaptive AI model selection: frontier models are escalation options, not universal requirements. Experimental/low-consequence work may intentionally use local or smaller models when the bounded task and external verification make that sufficient.

## Changes

- update `skills/README.md` with project-local ownership/adoption rules;
- add `docs/engineering/ai-model-selection.md` as the canonical model-selection/escalation guidance;
- distinguish model reasoning capability from execution authority and correctness evidence;
- require project-local skills to own project-specific tooling, evidence, completion, and model escalation policies;
- avoid hard-coding vendors/models unless exact-model behavior is itself under test.

## Invariants

- shared skills do not silently become active in every project;
- project-local skills cannot weaken applicable organization security/governance standards;
- frontier-model use is not required by default, including for Experimental projects;
- weaker models do not justify weaker verification/provenance/authority controls;
- stronger/frontier models do not replace deterministic verification, independent evidence, or required human/governance disposition.

## Related

- `.github#72`
- meta repository PR `hackelia-micrantha/hackelia-micrantha#37`

## Validation

Documentation-only change. Review should focus on ownership consistency with existing repository authority boundaries and avoiding model tier as a security/authority primitive.