### PR TITLE
Classify first repository source/distribution postures

### DIFF
--- a/docs/architecture/source-exposure-topologies.md
+++ b/docs/architecture/source-exposure-topologies.md
@@ -33,6 +33,8 @@ publicDistributionRepository: owner/repository | null
 
 During migration these fields are optional. Once any primary posture field is present, `sourceExposure`, `repositoryRole`, and `distributionMode` must be declared together.
 
+`distributionMode` is repository-local: it describes the primary downstream acquisition mode represented by **this repository surface**, not the eventual acquisition mode of the project as a whole. A private canonical build/release repository that publishes through a separate public binary repository should therefore normally declare `distributionMode=internal` (or `none` when it exposes no consumer acquisition surface), while the public distribution repository declares `distributionMode=binary`.
+
 `visibility` remains separate. It describes GitHub access, not product authority or source-disclosure intent.
 
 ## Topology A — public-source canonical project
@@ -66,6 +68,7 @@ Use this when implementation remains private but unauthenticated/public consumer
 private canonical repository
   sourceExposure=private
   repositoryRole=canonical
+  distributionMode=internal
   implementation/release authority
         |
         | authorized reviewed release
@@ -99,6 +102,7 @@ Use this when canonical authority remains private but selected implementation/co
 private canonical repository
   sourceExposure=private
   repositoryRole=canonical
+  distributionMode=internal
         |
         | reviewed one-way projection
         v
@@ -144,6 +148,7 @@ Use this when a project wants public documentation, schemas, examples, interoper
 private canonical repository
   sourceExposure=private
   repositoryRole=canonical
+  distributionMode=internal
         |
         | explicit allow-listed publication
         v
@@ -230,6 +235,7 @@ Avoid:
 
 - interpreting `-community` as `distribution`, `projection`, or `canonical` without metadata;
 - interpreting `visibility=public` as `sourceExposure=public`;
+- recording a public distribution mode on a separate private canonical repository merely because the project eventually ships that way;
 - exporting private implementation source solely so a public Nix flake can build it;
 - requiring ordinary downstream endpoints to possess private source credentials when they only need released artifacts;
 - allowing a public projection to silently fork canonical contracts;

--- a/metadata/repositories.json
+++ b/metadata/repositories.json
@@ -97,6 +97,12 @@
         "read-only host integration contracts"
       ],
       "requiredFiles": ["README.md"],
+      "sourceExposure": "private",
+      "repositoryRole": "canonical",
+      "implementationAuthority": "hackelia-micrantha/invokrum",
+      "releaseAuthority": "hackelia-micrantha/invokrum",
+      "distributionMode": "internal",
+      "publicDistributionRepository": "hackelia-micrantha/invokrum-community",
       "notes": "Mechanism, not policy; does not own workflow state, authorization, execution, or task completion."
     },
     {
@@ -109,6 +115,12 @@
       "monitor": true,
       "authority": ["public Invokrum documentation, examples, and community distribution"],
       "requiredFiles": ["README.md"],
+      "sourceExposure": "none",
+      "repositoryRole": "distribution",
+      "implementationAuthority": "hackelia-micrantha/invokrum",
+      "releaseAuthority": "hackelia-micrantha/invokrum",
+      "distributionMode": "binary",
+      "canonicalRepository": "hackelia-micrantha/invokrum",
       "notes": "Public surface does not independently redefine private implementation authority."
     },
     {
@@ -125,6 +137,12 @@
         "experimental MCP HTTP authorization adapters"
       ],
       "requiredFiles": ["README.md"],
+      "sourceExposure": "private",
+      "repositoryRole": "canonical",
+      "implementationAuthority": "hackelia-micrantha/keylix",
+      "releaseAuthority": "hackelia-micrantha/keylix",
+      "distributionMode": "internal",
+      "publicDistributionRepository": "hackelia-micrantha/keylix-community",
       "notes": "Proof of possession and sender binding do not establish application authorization, policy, or task correctness."
     },
     {
@@ -136,7 +154,13 @@
       "archived": false,
       "monitor": true,
       "authority": ["public Keylix documentation, examples, and community distribution"],
-      "requiredFiles": ["README.md"]
+      "requiredFiles": ["README.md"],
+      "sourceExposure": "public",
+      "repositoryRole": "projection",
+      "implementationAuthority": "hackelia-micrantha/keylix",
+      "releaseAuthority": "hackelia-micrantha/keylix",
+      "distributionMode": "source",
+      "canonicalRepository": "hackelia-micrantha/keylix"
     },
     {
       "repository": "hackelia-micrantha/hyperion",
@@ -226,7 +250,12 @@
       "archived": false,
       "monitor": true,
       "authority": ["public Kotlin Multiplatform SDK and application foundation"],
-      "requiredFiles": ["README.md"]
+      "requiredFiles": ["README.md"],
+      "sourceExposure": "public",
+      "repositoryRole": "canonical",
+      "implementationAuthority": "hackelia-micrantha/bluebell",
+      "releaseAuthority": "hackelia-micrantha/bluebell",
+      "distributionMode": "source"
     },
     {
       "repository": "hackelia-micrantha/amaryllis",
@@ -237,7 +266,12 @@
       "archived": false,
       "monitor": true,
       "authority": ["React Native on-device multimodal inference and governed UI foundation"],
-      "requiredFiles": ["README.md"]
+      "requiredFiles": ["README.md"],
+      "sourceExposure": "public",
+      "repositoryRole": "canonical",
+      "implementationAuthority": "hackelia-micrantha/amaryllis",
+      "releaseAuthority": "hackelia-micrantha/amaryllis",
+      "distributionMode": "source"
     },
     {
       "repository": "hackelia-micrantha/digitalis",
@@ -292,7 +326,12 @@
       "archived": false,
       "monitor": true,
       "authority": ["mobile platform engineering golden path and reference distribution"],
-      "requiredFiles": ["README.md"]
+      "requiredFiles": ["README.md"],
+      "sourceExposure": "public",
+      "repositoryRole": "canonical",
+      "implementationAuthority": "hackelia-micrantha/morifolium",
+      "releaseAuthority": "hackelia-micrantha/morifolium",
+      "distributionMode": "source"
     },
     {
       "repository": "hackelia-micrantha/repora",
@@ -306,7 +345,12 @@
         "repository topology and reconciliation tooling",
         "managed repository artifacts and posture evidence"
       ],
-      "requiredFiles": ["README.md"]
+      "requiredFiles": ["README.md"],
+      "sourceExposure": "public",
+      "repositoryRole": "canonical",
+      "implementationAuthority": "hackelia-micrantha/repora",
+      "releaseAuthority": "hackelia-micrantha/repora",
+      "distributionMode": "source"
     },
     {
       "repository": "hackelia-micrantha/calathea-community",
@@ -318,6 +362,11 @@
       "monitor": true,
       "authority": ["canonical reusable Calathea core, product contracts, architecture, and executable"],
       "requiredFiles": ["README.md"],
+      "sourceExposure": "public",
+      "repositoryRole": "canonical",
+      "implementationAuthority": "hackelia-micrantha/calathea-community",
+      "releaseAuthority": "hackelia-micrantha/calathea-community",
+      "distributionMode": "source",
       "notes": "This public repository is intentionally authoritative for reusable Calathea semantics."
     },
     {
@@ -330,6 +379,11 @@
       "monitor": true,
       "authority": ["private Calathea composition, portfolio data, dogfood operations, and non-public extensions"],
       "requiredFiles": ["README.md", "public-core.lock.toml"],
+      "sourceExposure": "private",
+      "repositoryRole": "internal",
+      "implementationAuthority": "hackelia-micrantha/calathea",
+      "releaseAuthority": "hackelia-micrantha/calathea",
+      "distributionMode": "internal",
       "notes": "Must not fork the reusable semantics owned by calathea-community."
     },
     {

--- a/tests/test_source_posture.py
+++ b/tests/test_source_posture.py
@@ -49,7 +49,7 @@ class SourcePostureValidationTests(unittest.TestCase):
             visibility="private",
             source_exposure="private",
             repository_role="canonical",
-            distribution_mode="binary",
+            distribution_mode="internal",
             implementationAuthority="hackelia-micrantha/invokrum",
             releaseAuthority="hackelia-micrantha/invokrum",
             publicDistributionRepository="hackelia-micrantha/invokrum-community",
@@ -78,7 +78,7 @@ class SourcePostureValidationTests(unittest.TestCase):
             visibility="private",
             source_exposure="private",
             repository_role="canonical",
-            distribution_mode="binary",
+            distribution_mode="internal",
             publicDistributionRepository="hackelia-micrantha/keylix-community",
         )
         projection = self.entry(
@@ -191,7 +191,7 @@ class SourcePostureValidationTests(unittest.TestCase):
             visibility="private",
             source_exposure="private",
             repository_role="canonical",
-            distribution_mode="binary",
+            distribution_mode="internal",
             publicDistributionRepository="hackelia-micrantha/internal-dist",
         )
         distribution = self.entry(
@@ -214,7 +214,7 @@ class SourcePostureValidationTests(unittest.TestCase):
             visibility="private",
             source_exposure="private",
             repository_role="canonical",
-            distribution_mode="binary",
+            distribution_mode="internal",
             monitor=True,
             publicDistributionRepository="hackelia-micrantha/invokrum-community",
         )
@@ -235,6 +235,7 @@ class SourcePostureValidationTests(unittest.TestCase):
         )
 
         self.assertIn("classified: 2/2 repositories", report)
+        self.assertIn("canonical/private/internal", report)
         self.assertIn("distribution/none/binary", report)
         self.assertIn(
             "invokrum-community --canonical--> hackelia-micrantha/invokrum",


### PR DESCRIPTION
Implements the first real-registry migration slice of #66 / hackelia-micrantha#35 and corrects the reference semantics discovered during review.

## Changes

- clarify that `distributionMode` is repository-local, not the eventual project-wide acquisition path;
- use `distributionMode=internal` for private canonical build/release repositories whose public acquisition surface is a separate repository;
- keep public source/binary modes on the repository surface that actually exposes them;
- update reference tests for Invokrum and Keylix;
- classify real registry entries for:
  - Invokrum canonical/community;
  - Keylix canonical/community;
  - Calathea public reusable core/private composition;
  - Repora;
  - Bluebell;
  - Amaryllis;
  - Morifolium.

## Deliberate deferrals

- Testule is not classified yet because the selected target posture is private canonical + public binary distribution, while the registry still records `testule` as public. Classify it only after the actual visibility cutover is evidenced.
- Anthesis, Sandcastle, Modolia, Hyperion, Digitalis, Myosotis, Envuscator, Achillea, Phyllotaxis, and Dubnium community remain incremental follow-ups where exact source/artifact/authority roles still need project-local reconciliation.

This keeps the migration evidence-driven and avoids encoding target state as if it were already operational.

Refs #66
Refs #68
Refs hackelia-micrantha/hackelia-micrantha#35