### PR TITLE
automation: bind label dry-runs to deterministic plan identity

### DIFF
--- a/.github/workflows/label-sync-report.yml
+++ b/.github/workflows/label-sync-report.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           python tools/label_sync.py plan \
             --repository hackelia-micrantha/.github \
+            --control-revision "$GITHUB_SHA" \
             --output-json label-sync-plan.json \
             --output-markdown label-sync-plan.md
           cat label-sync-plan.md >> "$GITHUB_STEP_SUMMARY"

--- a/tests/test_label_sync.py
+++ b/tests/test_label_sync.py
@@ -150,6 +150,19 @@ class LabelSyncTests(unittest.TestCase):
             with_unrelated_local_label["preservedRepositoryLabels"],
         )
 
+        with_selected_alias = label_sync.plan(
+            self.manifest,
+            repo,
+            [{"name": "CI", "color": "ededed", "description": "Legacy CI."}],
+            control_revision=revision,
+        )
+        self.assertNotEqual(baseline["planSha256"], with_selected_alias["planSha256"])
+        area_ci = next(
+            item for item in with_selected_alias["actions"] if item["label"] == "area:ci"
+        )
+        self.assertEqual(area_ci["action"], "migration")
+        self.assertFalse(area_ci["initialMutationEligible"])
+
         different_revision = label_sync.plan(
             self.manifest,
             repo,

--- a/tests/test_label_sync.py
+++ b/tests/test_label_sync.py
@@ -101,7 +101,7 @@ class LabelSyncTests(unittest.TestCase):
         self.assertEqual(actions["status:ready"]["action"], "no-op")
         self.assertFalse(actions["status:ready"]["initialMutationEligible"])
         self.assertEqual(actions["priority:P1"]["action"], "update")
-        self.assertTrue(actions["priority:P1"]["initialMutationEligible"])
+        self.assertFalse(actions["priority:P1"]["initialMutationEligible"])
         self.assertEqual(actions["priority:P1"]["existing"][0]["color"], "ffffff")
         self.assertEqual(actions["priority:P1"]["desired"]["color"], "d93f0b")
         self.assertEqual(actions["priority:P1"]["existing"][0]["description"], "Old.")
@@ -200,7 +200,7 @@ class LabelSyncTests(unittest.TestCase):
                 {
                     "label": "priority:P1",
                     "action": "update",
-                    "initialMutationEligible": True,
+                    "initialMutationEligible": False,
                     "existing": [
                         {"name": "priority:P1", "color": "ffffff", "description": "Old."}
                     ],

--- a/tests/test_label_sync.py
+++ b/tests/test_label_sync.py
@@ -90,20 +90,30 @@ class LabelSyncTests(unittest.TestCase):
             {"name": "workflow", "color": "ededed", "description": ""},
         ]
 
-        result = label_sync.plan(manifest, "hackelia-micrantha/example", current)
+        result = label_sync.plan(
+            manifest,
+            "hackelia-micrantha/example",
+            current,
+            control_revision="abc123",
+        )
         actions = {item["label"]: item for item in result["actions"]}
 
         self.assertEqual(actions["status:ready"]["action"], "no-op")
+        self.assertFalse(actions["status:ready"]["initialMutationEligible"])
         self.assertEqual(actions["priority:P1"]["action"], "update")
+        self.assertTrue(actions["priority:P1"]["initialMutationEligible"])
         self.assertEqual(actions["priority:P1"]["existing"][0]["color"], "ffffff")
         self.assertEqual(actions["priority:P1"]["desired"]["color"], "d93f0b")
         self.assertEqual(actions["priority:P1"]["existing"][0]["description"], "Old.")
         self.assertEqual(actions["priority:P1"]["desired"]["description"], "Next up.")
         self.assertEqual(actions["type:bug"]["action"], "migration")
+        self.assertFalse(actions["type:bug"]["initialMutationEligible"])
         self.assertEqual(actions["type:bug"]["existing"][0]["name"], "BUG")
         self.assertEqual(actions["area:ci"]["action"], "create")
+        self.assertTrue(actions["area:ci"]["initialMutationEligible"])
         self.assertEqual(actions["area:ci"]["existing"], [])
         self.assertEqual(actions["type:feature"]["action"], "collision")
+        self.assertFalse(actions["type:feature"]["initialMutationEligible"])
         self.assertEqual(
             {item["name"] for item in actions["type:feature"]["existing"]},
             {"type:feature", "enhancement"},
@@ -111,17 +121,86 @@ class LabelSyncTests(unittest.TestCase):
         self.assertEqual(
             result["preservedRepositoryLabels"], ["status:deferred", "workflow"]
         )
+        self.assertEqual(result["controlRevision"], "abc123")
+        self.assertEqual(len(result["manifestSha256"]), 64)
+        self.assertEqual(len(result["planSha256"]), 64)
         self.assertFalse(result["mutates"])
 
-    def test_render_includes_exact_existing_and_desired_metadata(self) -> None:
+    def test_plan_digest_binds_relevant_state_and_ignores_preserved_labels(self) -> None:
+        repo = "hackelia-micrantha/.github"
+        revision = "a" * 40
+
+        baseline = label_sync.plan(
+            self.manifest,
+            repo,
+            [],
+            control_revision=revision,
+        )
+        with_unrelated_local_label = label_sync.plan(
+            self.manifest,
+            repo,
+            [{"name": "workflow", "color": "ededed", "description": "Local."}],
+            control_revision=revision,
+        )
+        self.assertEqual(
+            baseline["planSha256"], with_unrelated_local_label["planSha256"]
+        )
+        self.assertNotEqual(
+            baseline["preservedRepositoryLabels"],
+            with_unrelated_local_label["preservedRepositoryLabels"],
+        )
+
+        different_revision = label_sync.plan(
+            self.manifest,
+            repo,
+            [],
+            control_revision="b" * 40,
+        )
+        self.assertNotEqual(baseline["planSha256"], different_revision["planSha256"])
+
+        first_label = self.manifest["labels"][0]
+        selected_state_changed = label_sync.plan(
+            self.manifest,
+            repo,
+            [first_label],
+            control_revision=revision,
+        )
+        self.assertNotEqual(
+            baseline["planSha256"], selected_state_changed["planSha256"]
+        )
+
+        changed_manifest = copy.deepcopy(self.manifest)
+        changed_manifest["labels"][0]["description"] = "Changed desired state."
+        manifest_changed = label_sync.plan(
+            changed_manifest,
+            repo,
+            [],
+            control_revision=revision,
+        )
+        self.assertNotEqual(
+            baseline["manifestSha256"], manifest_changed["manifestSha256"]
+        )
+        self.assertNotEqual(baseline["planSha256"], manifest_changed["planSha256"])
+
+    def test_canonical_json_is_key_order_independent(self) -> None:
+        left = {"b": 2, "a": {"d": 4, "c": 3}}
+        right = {"a": {"c": 3, "d": 4}, "b": 2}
+        self.assertEqual(label_sync.canonical_json(left), label_sync.canonical_json(right))
+        self.assertEqual(label_sync.sha256_json(left), label_sync.sha256_json(right))
+
+    def test_render_includes_exact_identity_and_metadata(self) -> None:
         value = {
             "repository": "hackelia-micrantha/example",
+            "controlRevision": "abc123",
+            "manifestSha256": "1" * 64,
+            "planSha256": "2" * 64,
             "mode": "report-only",
             "mutates": False,
             "actions": [
                 {
                     "label": "priority:P1",
                     "action": "update",
+                    "initialMutationEligible": True,
                     "existing": [
                         {"name": "priority:P1", "color": "ffffff", "description": "Old."}
                     ],
@@ -136,8 +215,12 @@ class LabelSyncTests(unittest.TestCase):
             "preservedRepositoryLabels": [],
         }
         text = label_sync.render(value)
+        self.assertIn("Control revision: `abc123`", text)
+        self.assertIn(f"Manifest SHA-256: `{'1' * 64}`", text)
+        self.assertIn(f"Plan SHA-256: `{'2' * 64}`", text)
         self.assertIn("`#ffffff` — Old.", text)
         self.assertIn("`#d93f0b` — Next up.", text)
+        self.assertIn("Initial write candidate", text)
         self.assertIn("Mutation: **disabled**", text)
 
     def test_unallowlisted_repository_is_rejected(self) -> None:

--- a/tools/label_sync.py
+++ b/tools/label_sync.py
@@ -22,7 +22,7 @@ ROOT_FIELDS = {"$schema", "schemaVersion", "organization", "labels", "repositori
 LABEL_FIELDS = {"name", "color", "description", "aliases"}
 REPOSITORY_FIELDS = {"repository", "mode", "labels", "notes"}
 PLAN_SCHEMA_VERSION = 1
-INITIAL_MUTATION_ACTIONS = {"create", "update"}
+INITIAL_MUTATION_ACTIONS = {"create"}
 
 
 def load(path: Path) -> Any:

--- a/tools/label_sync.py
+++ b/tools/label_sync.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -20,6 +21,8 @@ PREFIXES = ("priority:", "status:", "type:", "area:", "maturity:")
 ROOT_FIELDS = {"$schema", "schemaVersion", "organization", "labels", "repositories"}
 LABEL_FIELDS = {"name", "color", "description", "aliases"}
 REPOSITORY_FIELDS = {"repository", "mode", "labels", "notes"}
+PLAN_SCHEMA_VERSION = 1
+INITIAL_MUTATION_ACTIONS = {"create", "update"}
 
 
 def load(path: Path) -> Any:
@@ -27,6 +30,20 @@ def load(path: Path) -> Any:
         return json.loads(path.read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError) as exc:
         raise ValueError(f"cannot load {path}: {exc}") from None
+
+
+def canonical_json(value: Any) -> str:
+    """Return deterministic JSON suitable for hashing and evidence identity."""
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def sha256_json(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
 
 
 def documented(path: Path) -> set[str]:
@@ -167,8 +184,40 @@ def snapshot(name: str, value: dict[str, Any]) -> dict[str, str]:
     }
 
 
+def plan_identity(
+    manifest: dict[str, Any],
+    repo: str,
+    control_revision: str | None,
+    selected_labels: list[str],
+    actions: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build the mutation-relevant identity; preserved local labels are excluded."""
+    return {
+        "schemaVersion": PLAN_SCHEMA_VERSION,
+        "repository": repo,
+        "controlRevision": control_revision,
+        "manifestSha256": sha256_json(manifest),
+        "selectedLabels": selected_labels,
+        "actions": [
+            {
+                "label": item["label"],
+                "action": item["action"],
+                "existing": item["existing"],
+                "desired": item["desired"],
+                "reason": item["reason"],
+                "initialMutationEligible": item["initialMutationEligible"],
+            }
+            for item in actions
+        ],
+    }
+
+
 def plan(
-    manifest: dict[str, Any], repo: str, current: list[dict[str, Any]]
+    manifest: dict[str, Any],
+    repo: str,
+    current: list[dict[str, Any]],
+    *,
+    control_revision: str | None = None,
 ) -> dict[str, Any]:
     adoption = next(
         (item for item in manifest["repositories"] if item["repository"] == repo),
@@ -239,6 +288,7 @@ def plan(
                 "existing": before,
                 "desired": desired,
                 "reason": reason,
+                "initialMutationEligible": action in INITIAL_MUTATION_ACTIONS,
             }
         )
 
@@ -246,8 +296,22 @@ def plan(
     summary: dict[str, int] = {}
     for item in actions:
         summary[item["action"]] = summary.get(item["action"], 0) + 1
+
+    selected_labels = list(adoption["labels"])
+    identity = plan_identity(
+        manifest,
+        repo,
+        control_revision,
+        selected_labels,
+        actions,
+    )
     return {
+        "schemaVersion": PLAN_SCHEMA_VERSION,
         "repository": repo,
+        "controlRevision": control_revision,
+        "manifestSha256": identity["manifestSha256"],
+        "planSha256": sha256_json(identity),
+        "selectedLabels": selected_labels,
         "mode": "report-only",
         "mutates": False,
         "summary": summary,
@@ -309,19 +373,24 @@ def format_desired(value: dict[str, str]) -> str:
 
 
 def render(value: dict[str, Any]) -> str:
+    control_revision = value.get("controlRevision")
     lines = [
         "# Micrantha label synchronization plan",
         "",
         f"Repository: `{value['repository']}`",
+        f"Control revision: `{control_revision}`" if control_revision else "Control revision: **unbound**",
+        f"Manifest SHA-256: `{value.get('manifestSha256', 'unavailable')}`",
+        f"Plan SHA-256: `{value.get('planSha256', 'unavailable')}`",
         "Mode: `report-only`",
         "Mutation: **disabled**",
         "",
-        "| Label | Action | Existing | Desired | Reason |",
-        "| --- | --- | --- | --- | --- |",
+        "| Label | Action | Initial write candidate | Existing | Desired | Reason |",
+        "| --- | --- | --- | --- | --- | --- |",
     ]
     lines += [
         (
             f"| `{item['label']}` | {item['action']} | "
+            f"{'yes' if item.get('initialMutationEligible') else 'no'} | "
             f"{format_existing(item['existing'])} | {format_desired(item['desired'])} | "
             f"{escape(item['reason'])} |"
         )
@@ -331,7 +400,12 @@ def render(value: dict[str, Any]) -> str:
     lines += ["", f"Out-of-scope repository labels preserved: **{len(preserved)}**"]
     if preserved:
         lines += ["", ", ".join(f"`{name}`" for name in preserved)]
-    lines += ["", "Evidence only: no apply, rename, or delete operation exists.", ""]
+    lines += [
+        "",
+        "Initial write candidate is an operation classification only; this report grants no authority.",
+        "Evidence only: no apply, rename, or delete operation exists.",
+        "",
+    ]
     return "\n".join(lines)
 
 
@@ -347,6 +421,7 @@ def main() -> int:
     planner = sub.add_parser("plan")
     planner.add_argument("--repository", required=True)
     planner.add_argument("--current-labels", type=Path)
+    planner.add_argument("--control-revision", default=os.environ.get("GITHUB_SHA"))
     planner.add_argument("--output-json", type=Path)
     planner.add_argument("--output-markdown", type=Path)
     args = parser.parse_args()
@@ -376,7 +451,12 @@ def main() -> int:
         )
         if not isinstance(current, list):
             raise ValueError("current labels must be a JSON array")
-        result = plan(manifest, args.repository, current)
+        result = plan(
+            manifest,
+            args.repository,
+            current,
+            control_revision=args.control_revision,
+        )
     except ValueError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2


### PR DESCRIPTION
## Outcome

Land the non-mutating plan-identity slice of #79 independently of the still-reviewed write-authority design in #76/#78.

## Included

- deterministic canonical JSON and SHA-256 plan identity;
- semantic manifest digest;
- explicit `.github` control-plane revision binding;
- selected label/action snapshots in the digest;
- `initialMutationEligible` evidence classification for **create only**;
- update/migration/collision/no-op rows remain non-mutating;
- preserved/local labels remain outside the digest unless they affect selected canonical/alias/case state;
- tests proving revision, manifest, and selected-state changes alter the digest while unrelated preserved labels do not;
- report workflow explicitly binds plans to `GITHUB_SHA`.

## Authority boundary

This PR remains report-only. It adds no `apply` command, no write-scoped workflow, no credential, no label mutation, no metadata update, and no migration/delete behavior. `initialMutationEligible` is evidence classification only and grants no authority.

The write path in #79 remains blocked by #76/#78.

Related: #79, #27, #76, PR #75.