### PR TITLE
docs: reconcile portfolio catalogue and repository census

### DIFF
--- a/docs/architecture/repository-catalogue.md
+++ b/docs/architecture/repository-catalogue.md
@@ -1,16 +1,16 @@
 # Micrantha repository responsibility catalogue
 
-This catalogue records organization-level project classification, maturity, authoritative responsibility, and important non-responsibilities. It is the default source for deciding where work, contracts, issues, and public claims belong.
+This catalogue records organization-level project classification, role, lifecycle, authoritative responsibility, and important non-responsibilities. It is the default explanatory source for deciding where work, contracts, issues, and public claims belong.
 
-Detailed implementation, support, licensing, and release evidence remains in each authoritative repository. When this catalogue conflicts with current repository evidence, treat the conflict as governance drift: correct the catalogue or explicitly change ownership through review rather than silently relying on the inconsistency.
+Canonical project identity and portfolio tier are owned by `hackelia-micrantha/hackelia-micrantha/registry/projects.yaml`. This catalogue explains responsibility and repository boundaries; it must not independently add, remove, or re-tier portfolio projects. Detailed implementation, support, licensing, and release evidence remains in each authoritative repository. When this catalogue conflicts with the canonical registry or current repository evidence, treat the conflict as governance drift: correct the catalogue or explicitly change ownership through review rather than silently relying on the inconsistency.
 
-**Catalogue baseline:** 2026-09-04
+**Catalogue baseline:** 2026-09-11
 
 ## How to use this catalogue
 
 Before creating or moving work, determine:
 
-1. Which repository owns the affected contract or outcome?
+1. Which project and repository own the affected contract or outcome?
 2. Is the work product implementation, composition, provider integration, laboratory evidence, community packaging, public communication, or shared engineering substrate?
 3. Does the change alter another repository's authoritative boundary?
 4. Is current repository placement transitional?
@@ -18,15 +18,16 @@ Before creating or moving work, determine:
 
 A runtime dependency does not imply governance authority. A laboratory finding does not automatically change a product contract. A public site does not create product truth. A distribution composes components without assuming their internal authority. A trust-domain label describes context; it does not grant permission.
 
-## Classification, role, and lifecycle
+## Portfolio, classification, role, and lifecycle
 
 Keep these dimensions separate:
 
-- **classification** describes the portfolio/public grouping, where applicable: solution or laboratory;
-- **role** describes the primary architectural function: solution, platform, infrastructure, library/protocol, tooling, design-system substrate, laboratory/research, or meta/public surface;
-- **lifecycle** describes maturity/support expectations independently of role.
+- **portfolio** describes intentional portfolio presentation: `featured`, `supporting`, explicit `false`, or omitted/undecided. The canonical project registry owns this dimension;
+- **classification** describes solution/laboratory grouping where applicable and does not imply portfolio membership;
+- **role** describes the primary architectural function: solution, platform, infrastructure, library/protocol, tooling, design-system substrate, laboratory/research, creative, or meta/public surface;
+- **lifecycle** describes maturity/support expectations independently of role and portfolio tier.
 
-Lifecycle follows the organization lifecycle model. Do not infer maturity from repository visibility, age, recent activity, or public positioning.
+Do not infer portfolio membership from repository existence, visibility, activity, classification, role, or lifecycle. Portfolio-scoped reviews resolve membership from the canonical project registry and its reviewed inventory exclusions. Lifecycle follows the organization lifecycle model; do not infer maturity from repository visibility, age, recent activity, or public positioning.
 
 ## Repository role patterns
 
@@ -71,10 +72,10 @@ Examples include design-system contracts, reusable testing contracts, prompt/con
 
 | Repository or surface | Classification / role | Maturity | Authoritative responsibility | Does not own |
 | --- | --- | --- | --- | --- |
-| [`hackelia-micrantha/.github`](https://github.com/hackelia-micrantha/.github) | Organization governance / meta | Active | Organization defaults, governance, lifecycle, work-item conventions, prompt library, inherited issue/PR templates, shared engineering standards, public organization profile | Repository-specific implementation, licenses, CODEOWNERS, releases, branch rules, or deployment configuration |
-| [`hackelia-micrantha/hackelia-micrantha`](https://github.com/hackelia-micrantha/hackelia-micrantha) | Ecosystem coordination / meta | Active | Ecosystem registry, project relationships, aggregate maturity/status model, distribution and integration coordination | Organization-wide GitHub policy or project implementation |
-| [`hackelia-micrantha/web`](https://github.com/hackelia-micrantha/web) | Public website / public surface | Active | `micrantha.com` presentation, public navigation, and evidence-backed ecosystem communication | Product contracts, maturity by assertion, repository ownership, or support promises unsupported by authoritative projects |
-| [`profile/README.md`](../../profile/README.md) | GitHub organization profile / public surface | Active | Concise public organization overview and project map | Canonical lifecycle or responsibility rules; it projects this catalogue and governance model |
+| [`hackelia-micrantha/.github`](https://github.com/hackelia-micrantha/.github) | Organization governance / meta | Active | Organization defaults, governance, lifecycle, work-item conventions, prompt library, inherited issue/PR templates, shared engineering standards, public organization profile | Repository-specific implementation, licenses, CODEOWNERS, releases, branch rules, deployment configuration, or portfolio membership |
+| [`hackelia-micrantha/hackelia-micrantha`](https://github.com/hackelia-micrantha/hackelia-micrantha) | Ecosystem coordination / meta | Active | Canonical project identity and portfolio registry, project relationships, aggregate maturity/status model, distribution and integration coordination | Organization-wide GitHub policy or project implementation |
+| [`hackelia-micrantha/web`](https://github.com/hackelia-micrantha/web) | Public website / public surface | Active | `micrantha.com` presentation, public navigation, and evidence-backed ecosystem communication | Product contracts, portfolio membership by assertion, maturity by assertion, repository ownership, or support promises unsupported by authoritative projects |
+| [`profile/README.md`](../../profile/README.md) | GitHub organization profile / public surface | Active | Concise public organization overview and project map | Canonical lifecycle, portfolio membership, or responsibility rules; it projects reviewed organization/project evidence |
 
 ## Solutions, platforms, and product systems
 
@@ -99,6 +100,18 @@ Examples include design-system contracts, reusable testing contracts, prompt/con
 | **Modolia** — [`modolia`](https://github.com/hackelia-micrantha/modolia), [`modolia-community`](https://github.com/hackelia-micrantha/modolia-community) | Library/tooling / model-surface resolution | Incubating | Versioned model-surface registry schema, deterministic constraint evaluation, candidate ranking, route decisions, and replayable resolution records | Runtime provider routing, retries/fallback, model execution, or the authority that establishes governance constraints |
 | **Testule** — [`testule`](https://github.com/hackelia-micrantha/testule) | Library/tooling / testability contracts | Incubating | Language-neutral test plans, testability/data/environment/capability contracts, adapters, evidence normalization, gap analysis, and agent-accessible bounded testing capabilities | Replacing native test runners, CI/release authority, or treating evidence as authorization |
 | **Phyllotaxis** — [`phyllotaxis`](https://github.com/hackelia-micrantha/phyllotaxis) | Shared substrate / design system | Experimental | Shared semantic design tokens and themed UI substrate; Venation owns layout/primitives, with Chroma, Lamina, and Cambium as named design-system concerns | Product-specific information architecture, content, application behavior, or forcing identical branding across sites |
+
+## Additional registered project boundaries
+
+These registered projects do not require a `solution` or `laboratory` classification merely to participate in the portfolio. Their portfolio tier remains defined only in the canonical project registry.
+
+| Project and locations | Classification / role | Maturity | Authoritative responsibility | Does not own |
+| --- | --- | --- | --- | --- |
+| **Mobuild** — [`mobuild`](https://github.com/hackelia-micrantha/mobuild) with related component repositories | — / meta | Incubating | Cross-repository architecture and coordination for modular mobile build and security work; defines component relationships and trust/release boundaries, with Envuscator as the current product line | Envuscator implementation authority, unrelated mobile products, or automatic authority over component releases merely through coordination |
+| **Outermesh** — [`outermesh`](https://github.com/hackelia-micrantha/outermesh), with associated publication/web surfaces | — / solution | Experimental | Learning project that teaches software-engineering concepts through a bounded multiplayer security-simulation game and reference implementation | General organization education policy, unrelated security simulation products, or portfolio membership for its auxiliary repositories |
+| **The Fatherless / Entanglement of Ages** — authoritative creative source currently under `ryjen/the-fatherless`; public/marketing surfaces are separate projections | — / creative | Active | Canon, treatments, manuscript adaptation, publishing governance, and release preparation for the Entanglement of Ages creative project | Organization engineering standards, software project authority, or public disclosure of private creative-source material by implication |
+
+Garden and Scouter repository families remain explicitly outside portfolio scope under the reviewed canonical inventory. Their repositories may still be retained, inspected, or dispositioned for repository-health/lifecycle purposes without becoming portfolio projects.
 
 ## Laboratory, infrastructure, templates, and reference integrations
 
@@ -203,12 +216,13 @@ Repository location alone does not override documented architectural responsibil
 
 ## Unclassified or newly created repositories
 
-A repository not listed here is not automatically a solution, laboratory, supported product, or public project. Before making ecosystem claims, add a catalogue entry that identifies:
+A repository not listed here is not automatically a solution, laboratory, supported product, public project, or portfolio project. Before making ecosystem claims, add or reconcile the appropriate catalogue/registry entry that identifies:
 
 ```markdown
 ## Repository classification proposal
 
 - Repository:
+- Owning project (if any):
 - Purpose:
 - Classification:
 - Role:
@@ -222,7 +236,7 @@ A repository not listed here is not automatically a solution, laboratory, suppor
 - Overlap or migration from existing repositories:
 ```
 
-Private experiments and empty repository reservations may remain uncatalogued while Proposed, but they must not be used as evidence of implemented capability.
+If the proposal changes project identity or portfolio tier, update the canonical project registry rather than encoding that decision only here. Private experiments and empty repository reservations may remain uncatalogued while Proposed, but they must not be used as evidence of implemented capability or portfolio membership.
 
 ## Change control
 
@@ -231,8 +245,9 @@ Update this catalogue when:
 - a repository is created, transferred, renamed, split, merged, superseded, or archived;
 - source/community or engine/adapter boundaries change;
 - a contract moves between repositories;
-- project maturity changes;
+- project role or lifecycle changes;
+- a project identity/portfolio decision changes in the canonical registry and this explanatory catalogue is affected;
 - a transitional repository moves into the organization;
 - public documentation or release ownership changes materially.
 
-Changes that alter authority or a cross-repository contract should link the relevant QART, RFC, ADR, lifecycle record, or organization-owner decision. Editorial corrections and evidence refreshes may use a normal documentation pull request.
+Changes that alter authority or a cross-repository contract should link the relevant QART, RFC, ADR, lifecycle record, canonical-registry change, or organization-owner decision. Editorial corrections and evidence refreshes may use a normal documentation pull request.

--- a/docs/automation/repository-registry-coverage.md
+++ b/docs/automation/repository-registry-coverage.md
@@ -2,7 +2,9 @@
 
 This document records the organization-wide repository census used to bound the Micrantha repository-health baseline.
 
-The machine-readable registry in `metadata/repositories.json` remains the monitored set. Repositories listed here are **intentionally excluded from automated health checks until their ownership, lifecycle, or topology is explicitly reconciled**. Exclusion is not a claim that a repository is obsolete, unsupported, or safe to archive.
+The machine-readable registry in `metadata/repositories.json` remains the monitored set. Repositories listed here are **intentionally excluded from automated health checks until their ownership, lifecycle, topology, or repository-health contract is explicitly reconciled**. Exclusion is not a claim that a repository is obsolete, unsupported, outside the project portfolio, or safe to archive.
+
+Canonical project identity and portfolio tier are owned separately by `hackelia-micrantha/hackelia-micrantha/registry/projects.yaml`. Repository-health inclusion/exclusion must not be used to infer portfolio membership.
 
 ## Census method
 
@@ -15,7 +17,7 @@ For each unregistered repository this document records:
 - current GitHub archive state;
 - the reason it is not yet part of the monitored health baseline.
 
-Repository-local evidence and the canonical responsibility catalogue remain authoritative for implementation ownership and maturity.
+Repository-local evidence and the canonical responsibility catalogue remain authoritative for implementation ownership and maturity. The canonical project registry remains authoritative for project identity and portfolio tier.
 
 ## Current exclusions
 
@@ -27,17 +29,14 @@ These repositories predate the current responsibility catalogue or do not yet ha
 | --- | --- | --- | --- | --- |
 | `stimulus` | private | `main` | no | Unclassified historical testing/tooling surface; ownership review required. |
 | `micra` | private | `master` | no | Historical project/build tool; ownership and supersession review required. |
-| `outermesh` | private | `master` | no | Historical project surface; lifecycle decision required. |
-| `outermesh-book` | private | `master` | no | Historical publication surface associated with OuterMesh. |
-| `outermesh-web` | private | `master` | no | Historical web surface associated with OuterMesh. |
-| `garden` | private | `master` | no | Historical Garden project surface; lifecycle decision required. |
-| `garden-library` | private | `master` | no | Historical Garden shared library. |
-| `garden-sdk` | private | `master` | no | Historical Garden SDK. |
-| `garden-nursery` | private | `master` | no | Historical Garden frontend. |
-| `scouter` | private | `master` | no | Historical Scouter project surface; lifecycle decision required. |
-| `scouter-backend` | private | `master` | no | Historical Scouter backend. |
-| `scouter-frontend` | private | `master` | no | Historical Scouter frontend. |
-| `scouter-prototype` | private | `main` | no | Historical Android prototype. |
+| `garden` | private | `master` | no | Historical Garden project surface; explicitly outside portfolio scope; lifecycle/repository disposition remains separate work. |
+| `garden-library` | private | `master` | no | Historical Garden shared library; outside portfolio scope with its project family. |
+| `garden-sdk` | private | `master` | no | Historical Garden SDK; outside portfolio scope with its project family. |
+| `garden-nursery` | private | `master` | no | Historical Garden frontend; outside portfolio scope with its project family. |
+| `scouter` | private | `master` | no | Historical Scouter project surface; explicitly outside portfolio scope; lifecycle/repository disposition remains separate work. |
+| `scouter-backend` | private | `master` | no | Historical Scouter backend; outside portfolio scope with its project family. |
+| `scouter-frontend` | private | `master` | no | Historical Scouter frontend; outside portfolio scope with its project family. |
+| `scouter-prototype` | private | `main` | no | Historical Android prototype; outside portfolio scope with its project family. |
 | `sandbox` | private | `main` | no | Unclassified development-environment experiment; reconcile against Sandcastle/Dubnium before assigning authority. |
 | `codemux` | private | `main` | no | Unclassified live-coding tool; ownership review required. |
 | `lab-service` | private | `main` | no | Unclassified lab support service; ownership review required. |
@@ -45,19 +44,22 @@ These repositories predate the current responsibility catalogue or do not yet ha
 | `pura` | private | `main` | no | Unclassified application repository; lifecycle decision required. |
 | `yard` | private | `main` | no | Unclassified data-oriented repository; ownership review required. |
 
-### Current-project auxiliary candidates
+### Current-project repository-health exclusions
 
-These repositories are plausibly related to current Micrantha projects or shared infrastructure, but the current catalogue does not assign them an authoritative role. They remain outside health checks until topology is documented rather than inferred from naming.
+These repositories are associated with reviewed current projects or shared infrastructure, but are still outside automated health checks until their repository-level monitoring contract or auxiliary topology is explicitly reviewed. Their presence here does not make their project identity undecided.
 
 | Repository | Visibility | Default branch | Archived | Baseline disposition |
 | --- | --- | --- | --- | --- |
+| `outermesh` | private | `master` | no | Canonical root of the registered supporting Outermesh project; keep outside health monitoring until current required-file/default-branch expectations are reviewed. |
+| `outermesh-book` | private | `master` | no | Publication surface associated with the registered Outermesh project; auxiliary topology/monitoring contract still requires review. |
+| `outermesh-web` | private | `master` | no | Web surface associated with the registered Outermesh project; auxiliary topology/monitoring contract still requires review. |
 | `fortunes-service` | private | `main` | no | Candidate Fortunes service component; reconcile against canonical Fortunes composition. |
 | `fortunes-cli` | private | `master` | no | Candidate Fortunes CLI/adapter; reconcile before monitoring. |
 | `envuscator-web` | private | `main` | no | Candidate Envuscator web surface; catalogue/topology review required. |
 | `actions` | private | `main` | no | Candidate shared automation repository; determine whether `.github` supersedes or delegates any authority. |
-| `mobuild-project` | private | `main` | no | Candidate Mobuild component; project identity/topology review required. |
-| `mobuild-warden` | private | `main` | no | Candidate mobile security component; project identity/topology review required. |
-| `mobuild` | private | `main` | no | Candidate Mobuild platform; current relationship to Envuscator/other mobile projects must be explicit. |
+| `mobuild` | private | `main` | no | Canonical root of the registered supporting Mobuild coordination project; repository-health expectations remain intentionally unregistered pending monitoring review. |
+| `mobuild-project` | private | `main` | no | Component/coordination repository within the registered Mobuild project family; topology and monitoring responsibility require explicit review. |
+| `mobuild-warden` | private | `main` | no | Mobile security component within the registered Mobuild project family; topology and monitoring responsibility require explicit review. |
 | `bluebell-sdk` | private | `main` | no | Candidate private Bluebell component; reconcile with the public `bluebell` authority boundary. |
 | `download` | private | `main` | no | Candidate shared download service; owner and consumers must be documented before monitoring. |
 | `keylix-client` | private | `main` | yes | GitHub-archived Keylix mobile adapter; retained as historical topology, not a monitored current surface. |
@@ -73,6 +75,8 @@ A repository moves from this exclusion list into `metadata/repositories.json` on
 5. `requiredFiles` contains only files that are genuinely required for that repository type.
 
 An auxiliary repository may be registered with `monitor: false` when retaining topology/state in the registry is useful but health-file checks would create false positives.
+
+Portfolio tier is not a prerequisite for repository-health registration and repository-health inclusion is not evidence of portfolio membership.
 
 ## Private repository coverage policy
 
@@ -95,16 +99,17 @@ A long-lived personal access token is not required for the routine baseline and 
 For a new repository, transfer, public/private split, supersession, or archive event:
 
 1. identify the owning project or explicit organization-level responsibility;
-2. update the responsibility catalogue when the authority model changes;
-3. update `metadata/repositories.json` or this exclusion document in the same change;
-4. verify GitHub visibility, default branch, and archive state;
-5. keep community/mirror/projection repositories distinct from implementation authority;
-6. avoid adding required-file expectations until the repository's actual contract supports them;
-7. run repository health in non-blocking mode and review drift before making any threshold required.
+2. update the canonical project registry when project identity or portfolio tier changes;
+3. update the responsibility catalogue when the authority model changes;
+4. update `metadata/repositories.json` or this exclusion document in the same change;
+5. verify GitHub visibility, default branch, and archive state;
+6. keep community/mirror/projection repositories distinct from implementation authority;
+7. avoid adding required-file expectations until the repository's actual contract supports them;
+8. run repository health in non-blocking mode and review drift before making any threshold required.
 
 ## Baseline interpretation
 
-Repository health is a bounded evidence source, not an authority-transfer mechanism.
+Repository health is a bounded evidence source, not an authority-transfer or portfolio-selection mechanism.
 
 - `ok` means the workflow could verify the registered GitHub metadata and required-file contract.
 - `warning` or `error` is actionable drift that should be reviewed and, when justified, routed to the owning repository.


### PR DESCRIPTION
Closes #81.

## Summary

- define `portfolio` as a separate canonical project dimension owned by `hackelia-micrantha/hackelia-micrantha/registry/projects.yaml`
- stop describing `classification` as portfolio/public grouping
- clarify `.github` responsibility catalogue as explanatory boundary documentation rather than an independent portfolio-membership source
- add bounded current responsibility entries for Mobuild, Outermesh, and The Fatherless / Entanglement of Ages
- preserve Garden and Scouter as explicit non-portfolio repository families without promoting them into the project registry
- reconcile repository-health census language so resolved Mobuild/Outermesh project identities are no longer called unresolved candidates
- keep repository-health monitoring inclusion independent from project/portfolio identity

## Boundaries

- documentation only
- no project registry changes
- no portfolio membership/tier changes
- no repository-health metadata/workflow changes
- no repository visibility, branch, archive, or required-file mutations

## Validation

Review exact two-file documentation diff for authority drift; run configured repository validation if attached.