### PR TITLE
Add posture-aware release readiness evidence checker

### DIFF
--- a/.github/workflows/meta-validation.yml
+++ b/.github/workflows/meta-validation.yml
@@ -10,6 +10,7 @@ on:
       - metadata/**
       - tests/**
       - tools/label_sync.py
+      - tools/release_readiness.py
       - tools/repository_health.py
       - tools/source_posture.py
       - workflow-templates/**
@@ -25,6 +26,7 @@ on:
       - metadata/**
       - tests/**
       - tools/label_sync.py
+      - tools/release_readiness.py
       - tools/repository_health.py
       - tools/source_posture.py
       - workflow-templates/**

--- a/docs/architecture/release-readiness-evidence.md
+++ b/docs/architecture/release-readiness-evidence.md
@@ -1,0 +1,132 @@
+# Release-readiness evidence boundary
+
+This document describes the executable evidence boundary used by `tools/release_readiness.py`. The normative policy remains in:
+
+- `docs/standards/source-exposure-and-distribution.md`;
+- `docs/standards/releases.md`;
+- `docs/standards/cli-interoperability.md`;
+- `docs/standards/security.md`.
+
+The checker does not replace repository-owned build, package, release, signing, or language-specific validation.
+
+## Model
+
+```text
+repository-owned release/build tooling
+  -> build the real candidate artifact/package
+  -> inspect generated output
+  -> exercise the supported clean-consumer path
+  -> normalize bounded evidence
+            |
+            v
+metadata/release-readiness.schema.json
+            +
+metadata/repositories.json
+            |
+            v
+tools/release_readiness.py
+  -> posture/readiness decision
+```
+
+The registry is authoritative for repository topology and source/distribution posture. The evidence document reports what the candidate release actually did. A project must not copy its own posture classification into the evidence document as a second authority.
+
+## Producer responsibilities
+
+Repository-owned release tooling should generate evidence only after exercising the real candidate path. It is responsible for language/package-specific facts such as:
+
+- whether the package compiled implementation source;
+- whether acquisition required private repository credentials;
+- whether release inputs were immutable and cryptographically pinned;
+- what files and permissions appeared in the generated package/archive;
+- whether executable/man-page smoke checks passed;
+- whether a clean/cache-miss consumer path succeeded;
+- normalized release identity claims extracted from the surfaces the project can inspect;
+- whether the generated artifact contains prohibited private/security/development material.
+
+The organization checker does not fetch arbitrary URLs or infer those facts from prose.
+
+## Normalized identity
+
+`release.canonicalIdentity` is a project-normalized release identity such as `0.3.0`. `identityClaims` contains only mechanically discovered surfaces that the producer can normalize to that identity, for example:
+
+```json
+{
+  "canonicalIdentity": "0.3.0",
+  "identityClaims": {
+    "executable": "0.3.0",
+    "archive": "0.3.0",
+    "package": "0.3.0",
+    "manPage": "0.3.0",
+    "provenance": "0.3.0"
+  }
+}
+```
+
+A raw tag such as `v0.3.0` may be normalized by repository-owned tooling when the project's release contract explicitly defines that mapping. The organization checker compares normalized identities rather than inventing per-project version parsing rules.
+
+Missing mechanically unavailable claims are not fabricated. A supplied claim that disagrees with the canonical identity fails readiness.
+
+## Public binary distribution
+
+For a public surface declared `distributionMode=binary`, evidence must show at minimum:
+
+- acquisition mode is binary;
+- implementation source is not compiled by the public package path;
+- immutable acquisition is cryptographically pinned;
+- no private source credential is required;
+- a clean/cache-miss consumer path succeeds without private credentials;
+- generated artifacts do not contain private implementation source;
+- generated artifacts contain no credentials, signing keys, private security corpus, or development-only material.
+
+This is the expected Invokrum-style topology after its public binary distribution is operational.
+
+## Public source distribution
+
+For `distributionMode=source`, source-building is expected rather than suspicious. Evidence must show the source acquisition is immutable and credential-free for the public consumer path.
+
+This permits public canonical projects such as Repora and public source projections such as Keylix community without confusing source exposure with canonical implementation authority.
+
+## CLI completeness
+
+When `cli` evidence is present, the checker requires:
+
+- the executable path to exist in the inspected artifact list and be executable;
+- the section-1 man page at `share/man/man1/<name>.1`;
+- non-mutating smoke checks to have passed;
+- required operator/verification documentation to be present.
+
+A project that is not a CLI omits the `cli` object.
+
+## Clean-consumer evidence
+
+Public consumer surfaces must exercise a clean/cache-miss or equivalent acquisition path with private credentials unavailable. A warm Nix/store/package cache is not sufficient evidence because it can hide an invalid private-source authority dependency.
+
+`cleanConsumer.privateCredentialsAvailable=false` is an observation about the test environment. It is not a credential-discovery mechanism and must never contain credential values.
+
+## Artifact inspection
+
+The evidence schema records bounded booleans rather than artifact bodies. Do not embed package contents, secret candidates, private source snippets, fuzz corpora, or signing material in the evidence document.
+
+The repository-owned producer should retain enough local/CI diagnostics to explain a failure while keeping organization-level evidence minimal.
+
+## Verification
+
+Run from a checkout of this repository:
+
+```bash
+python tools/release_readiness.py path/to/release-readiness.json
+```
+
+Use another registry only for explicit fixture/testing work:
+
+```bash
+python tools/release_readiness.py \
+  --registry metadata/repositories.json \
+  path/to/release-readiness.json
+```
+
+A successful result means the supplied candidate evidence is mechanically consistent with the declared repository posture and cross-project release invariants represented by the checker. It does **not** grant release, signing, deployment, governance, or runtime authority.
+
+## Deliberate boundary
+
+The first executable profile intentionally does not define a universal package parser, network fetcher, signature verifier, or exception engine. Project-specific package inspection remains repository-owned. Any future exception mechanism must be explicit, reviewable, bounded to named checks, and must not turn the checker into an authority-bypass surface.

--- a/metadata/release-readiness.schema.json
+++ b/metadata/release-readiness.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/hackelia-micrantha/.github/blob/main/metadata/release-readiness.schema.json",
+  "title": "Micrantha normalized release-readiness evidence",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "repository",
+    "release",
+    "acquisition",
+    "inspection"
+  ],
+  "properties": {
+    "schemaVersion": {"const": 1},
+    "repository": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+    },
+    "release": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["releaseAuthority", "canonicalIdentity", "identityClaims"],
+      "properties": {
+        "releaseAuthority": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+        },
+        "canonicalIdentity": {"type": "string", "minLength": 1},
+        "identityClaims": {
+          "type": "object",
+          "additionalProperties": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "acquisition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "sourceBuild", "immutable", "requiresPrivateCredentials"],
+      "properties": {
+        "mode": {
+          "enum": ["source", "binary", "package", "closure", "internal", "none"]
+        },
+        "sourceBuild": {"type": "boolean"},
+        "immutable": {"type": "boolean"},
+        "requiresPrivateCredentials": {"type": "boolean"},
+        "cryptographicPins": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^sha256:[0-9a-f]{64}$"
+          }
+        }
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "kind", "executable"],
+        "properties": {
+          "path": {"type": "string", "minLength": 1, "not": {"pattern": "^/"}},
+          "kind": {"type": "string", "minLength": 1},
+          "executable": {"type": "boolean"}
+        }
+      }
+    },
+    "cli": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "executablePath",
+        "manPagePath",
+        "smokePassed",
+        "operatorDocsPresent"
+      ],
+      "properties": {
+        "executablePath": {"type": "string", "minLength": 1},
+        "manPagePath": {"type": "string", "minLength": 1},
+        "smokePassed": {"type": "boolean"},
+        "operatorDocsPresent": {"type": "boolean"}
+      }
+    },
+    "inspection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "privateImplementationSourcePresent",
+        "credentialsPresent",
+        "signingKeysPresent",
+        "privateSecurityCorpusPresent",
+        "developmentOnlyMaterialPresent"
+      ],
+      "properties": {
+        "privateImplementationSourcePresent": {"type": "boolean"},
+        "credentialsPresent": {"type": "boolean"},
+        "signingKeysPresent": {"type": "boolean"},
+        "privateSecurityCorpusPresent": {"type": "boolean"},
+        "developmentOnlyMaterialPresent": {"type": "boolean"}
+      }
+    },
+    "cleanConsumer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tested", "cacheMiss", "privateCredentialsAvailable", "passed"],
+      "properties": {
+        "tested": {"type": "boolean"},
+        "cacheMiss": {"type": "boolean"},
+        "privateCredentialsAvailable": {"type": "boolean"},
+        "passed": {"type": "boolean"}
+      }
+    }
+  }
+}

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import copy
+import unittest
+
+from tools import release_readiness
+
+
+class ReleaseReadinessTests(unittest.TestCase):
+    def registry(self, *repositories: dict[str, object]) -> dict[str, object]:
+        return {
+            "schemaVersion": 1,
+            "organization": "hackelia-micrantha",
+            "repositories": list(repositories),
+        }
+
+    def entry(
+        self,
+        repository: str,
+        *,
+        visibility: str,
+        source_exposure: str,
+        repository_role: str,
+        distribution_mode: str,
+        **extra: object,
+    ) -> dict[str, object]:
+        item: dict[str, object] = {
+            "repository": repository,
+            "visibility": visibility,
+            "sourceExposure": source_exposure,
+            "repositoryRole": repository_role,
+            "distributionMode": distribution_mode,
+        }
+        item.update(extra)
+        return item
+
+    def invokrum_registry(self) -> dict[str, object]:
+        canonical = self.entry(
+            "hackelia-micrantha/invokrum",
+            visibility="private",
+            source_exposure="private",
+            repository_role="canonical",
+            distribution_mode="internal",
+            implementationAuthority="hackelia-micrantha/invokrum",
+            releaseAuthority="hackelia-micrantha/invokrum",
+            publicDistributionRepository="hackelia-micrantha/invokrum-community",
+        )
+        distribution = self.entry(
+            "hackelia-micrantha/invokrum-community",
+            visibility="public",
+            source_exposure="none",
+            repository_role="distribution",
+            distribution_mode="binary",
+            implementationAuthority="hackelia-micrantha/invokrum",
+            releaseAuthority="hackelia-micrantha/invokrum",
+            canonicalRepository="hackelia-micrantha/invokrum",
+        )
+        return self.registry(canonical, distribution)
+
+    def binary_evidence(self) -> dict[str, object]:
+        return {
+            "schemaVersion": 1,
+            "repository": "hackelia-micrantha/invokrum-community",
+            "release": {
+                "releaseAuthority": "hackelia-micrantha/invokrum",
+                "canonicalIdentity": "0.3.0",
+                "identityClaims": {
+                    "executable": "0.3.0",
+                    "archive": "0.3.0",
+                    "package": "0.3.0",
+                    "manPage": "0.3.0",
+                    "provenance": "0.3.0",
+                },
+            },
+            "acquisition": {
+                "mode": "binary",
+                "sourceBuild": False,
+                "immutable": True,
+                "requiresPrivateCredentials": False,
+                "cryptographicPins": ["sha256:" + "a" * 64],
+            },
+            "artifacts": [
+                {"path": "bin/invokrum", "kind": "executable", "executable": True},
+                {
+                    "path": "share/man/man1/invokrum.1",
+                    "kind": "man",
+                    "executable": False,
+                },
+            ],
+            "cli": {
+                "executablePath": "bin/invokrum",
+                "manPagePath": "share/man/man1/invokrum.1",
+                "smokePassed": True,
+                "operatorDocsPresent": True,
+            },
+            "inspection": {
+                "privateImplementationSourcePresent": False,
+                "credentialsPresent": False,
+                "signingKeysPresent": False,
+                "privateSecurityCorpusPresent": False,
+                "developmentOnlyMaterialPresent": False,
+            },
+            "cleanConsumer": {
+                "tested": True,
+                "cacheMiss": True,
+                "privateCredentialsAvailable": False,
+                "passed": True,
+            },
+        }
+
+    def source_evidence(self, repository: str, release_authority: str) -> dict[str, object]:
+        return {
+            "schemaVersion": 1,
+            "repository": repository,
+            "release": {
+                "releaseAuthority": release_authority,
+                "canonicalIdentity": "0.2.0",
+                "identityClaims": {"package": "0.2.0"},
+            },
+            "acquisition": {
+                "mode": "source",
+                "sourceBuild": True,
+                "immutable": True,
+                "requiresPrivateCredentials": False,
+            },
+            "inspection": {
+                "privateImplementationSourcePresent": False,
+                "credentialsPresent": False,
+                "signingKeysPresent": False,
+                "privateSecurityCorpusPresent": False,
+                "developmentOnlyMaterialPresent": False,
+            },
+            "cleanConsumer": {
+                "tested": True,
+                "cacheMiss": True,
+                "privateCredentialsAvailable": False,
+                "passed": True,
+            },
+        }
+
+    def test_invokrum_public_binary_release_is_valid(self) -> None:
+        self.assertEqual(
+            release_readiness.validate_release_evidence(
+                self.invokrum_registry(), self.binary_evidence()
+            ),
+            [],
+        )
+
+    def test_binary_distribution_cannot_compile_private_implementation_source(self) -> None:
+        evidence = self.binary_evidence()
+        evidence["acquisition"]["sourceBuild"] = True
+
+        errors = release_readiness.validate_release_evidence(
+            self.invokrum_registry(), evidence
+        )
+
+        self.assertTrue(any("[binary.no-source-build]" in error for error in errors))
+
+    def test_public_binary_distribution_requires_cryptographic_pin(self) -> None:
+        evidence = self.binary_evidence()
+        evidence["acquisition"]["cryptographicPins"] = []
+
+        errors = release_readiness.validate_release_evidence(
+            self.invokrum_registry(), evidence
+        )
+
+        self.assertTrue(any("[binary.pin]" in error for error in errors))
+
+    def test_public_distribution_cannot_require_private_source_credentials(self) -> None:
+        evidence = self.binary_evidence()
+        evidence["acquisition"]["requiresPrivateCredentials"] = True
+        evidence["cleanConsumer"]["privateCredentialsAvailable"] = True
+
+        errors = release_readiness.validate_release_evidence(
+            self.invokrum_registry(), evidence
+        )
+
+        self.assertTrue(any("[acquisition.credentials]" in error for error in errors))
+        self.assertTrue(any("[consumer.clean]" in error for error in errors))
+
+    def test_binary_distribution_rejects_private_source_in_generated_artifact(self) -> None:
+        evidence = self.binary_evidence()
+        evidence["inspection"]["privateImplementationSourcePresent"] = True
+
+        errors = release_readiness.validate_release_evidence(
+            self.invokrum_registry(), evidence
+        )
+
+        self.assertTrue(any("[binary.private-source]" in error for error in errors))
+
+    def test_generated_artifact_rejects_secret_or_private_security_material(self) -> None:
+        evidence = self.binary_evidence()
+        evidence["inspection"]["credentialsPresent"] = True
+        evidence["inspection"]["privateSecurityCorpusPresent"] = True
+
+        errors = release_readiness.validate_release_evidence(
+            self.invokrum_registry(), evidence
+        )
+
+        self.assertTrue(any("[artifact.credentials]" in error for error in errors))
+        self.assertTrue(
+            any("[artifact.private-security-corpus]" in error for error in errors)
+        )
+
+    def test_cli_release_requires_executable_man_page_smoke_and_docs(self) -> None:
+        evidence = self.binary_evidence()
+        evidence["artifacts"] = [
+            {"path": "bin/invokrum", "kind": "executable", "executable": False}
+        ]
+        evidence["cli"]["smokePassed"] = False
+        evidence["cli"]["operatorDocsPresent"] = False
+
+        errors = release_readiness.validate_release_evidence(
+            self.invokrum_registry(), evidence
+        )
+
+        self.assertTrue(any("[cli.executable]" in error for error in errors))
+        self.assertTrue(any("[cli.man]" in error for error in errors))
+        self.assertTrue(any("[cli.smoke]" in error for error in errors))
+        self.assertTrue(any("[cli.docs]" in error for error in errors))
+
+    def test_release_identity_drift_fails_readiness(self) -> None:
+        evidence = self.binary_evidence()
+        evidence["release"]["identityClaims"]["manPage"] = "0.2.0"
+
+        errors = release_readiness.validate_release_evidence(
+            self.invokrum_registry(), evidence
+        )
+
+        self.assertTrue(any("identity claim 'manPage'" in error for error in errors))
+
+    def test_repora_public_source_build_is_valid(self) -> None:
+        repository = self.entry(
+            "hackelia-micrantha/repora",
+            visibility="public",
+            source_exposure="public",
+            repository_role="canonical",
+            distribution_mode="source",
+            implementationAuthority="hackelia-micrantha/repora",
+            releaseAuthority="hackelia-micrantha/repora",
+        )
+
+        self.assertEqual(
+            release_readiness.validate_release_evidence(
+                self.registry(repository),
+                self.source_evidence(
+                    "hackelia-micrantha/repora", "hackelia-micrantha/repora"
+                ),
+            ),
+            [],
+        )
+
+    def test_keylix_public_source_projection_keeps_private_canonical_authority(self) -> None:
+        canonical = self.entry(
+            "hackelia-micrantha/keylix",
+            visibility="private",
+            source_exposure="private",
+            repository_role="canonical",
+            distribution_mode="internal",
+            implementationAuthority="hackelia-micrantha/keylix",
+            releaseAuthority="hackelia-micrantha/keylix",
+            publicDistributionRepository="hackelia-micrantha/keylix-community",
+        )
+        projection = self.entry(
+            "hackelia-micrantha/keylix-community",
+            visibility="public",
+            source_exposure="public",
+            repository_role="projection",
+            distribution_mode="source",
+            canonicalRepository="hackelia-micrantha/keylix",
+            implementationAuthority="hackelia-micrantha/keylix",
+            releaseAuthority="hackelia-micrantha/keylix",
+        )
+
+        self.assertEqual(
+            release_readiness.validate_release_evidence(
+                self.registry(canonical, projection),
+                self.source_evidence(
+                    "hackelia-micrantha/keylix-community",
+                    "hackelia-micrantha/keylix",
+                ),
+            ),
+            [],
+        )
+
+    def test_calathea_public_canonical_source_release_is_valid(self) -> None:
+        public_core = self.entry(
+            "hackelia-micrantha/calathea-community",
+            visibility="public",
+            source_exposure="public",
+            repository_role="canonical",
+            distribution_mode="source",
+            implementationAuthority="hackelia-micrantha/calathea-community",
+            releaseAuthority="hackelia-micrantha/calathea-community",
+        )
+
+        self.assertEqual(
+            release_readiness.validate_release_evidence(
+                self.registry(public_core),
+                self.source_evidence(
+                    "hackelia-micrantha/calathea-community",
+                    "hackelia-micrantha/calathea-community",
+                ),
+            ),
+            [],
+        )
+
+    def test_release_authority_must_match_registry(self) -> None:
+        evidence = self.binary_evidence()
+        evidence["release"]["releaseAuthority"] = "hackelia-micrantha/invokrum-community"
+
+        errors = release_readiness.validate_release_evidence(
+            self.invokrum_registry(), evidence
+        )
+
+        self.assertTrue(any("[release.authority]" in error for error in errors))
+
+    def test_evidence_for_unclassified_repository_fails_closed(self) -> None:
+        registry = {
+            "schemaVersion": 1,
+            "organization": "hackelia-micrantha",
+            "repositories": [
+                {
+                    "repository": "hackelia-micrantha/legacy",
+                    "visibility": "public",
+                }
+            ],
+        }
+        evidence = copy.deepcopy(self.binary_evidence())
+        evidence["repository"] = "hackelia-micrantha/legacy"
+
+        errors = release_readiness.validate_release_evidence(registry, evidence)
+
+        self.assertEqual(
+            errors,
+            [
+                "[registry.unclassified] repository posture is not classified: hackelia-micrantha/legacy"
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/release_readiness.py
+++ b/tools/release_readiness.py
@@ -17,7 +17,10 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from tools import source_posture
+try:
+    from tools import source_posture
+except ModuleNotFoundError:  # direct `python tools/release_readiness.py ...`
+    import source_posture
 
 SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 PUBLIC_DISTRIBUTION_MODES = {"source", "binary", "package", "closure"}

--- a/tools/release_readiness.py
+++ b/tools/release_readiness.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Validate normalized release evidence against Micrantha repository posture.
+
+The checker is deliberately repository-neutral. Project-owned release tooling produces a
+small evidence document after building/inspecting its real package or artifact; this
+module compares that evidence with the organization repository registry. It does not
+fetch caller-selected URLs, build packages, sign artifacts, or reinterpret project
+package-manager semantics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from tools import source_posture
+
+SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+PUBLIC_DISTRIBUTION_MODES = {"source", "binary", "package", "closure"}
+
+
+def _repository_index(registry: Any) -> dict[str, dict[str, Any]]:
+    if not isinstance(registry, dict) or not isinstance(registry.get("repositories"), list):
+        return {}
+    return {
+        item["repository"]: item
+        for item in registry["repositories"]
+        if isinstance(item, dict) and isinstance(item.get("repository"), str)
+    }
+
+
+def _require_bool(container: Any, field: str, expected: bool, errors: list[str], check: str) -> None:
+    if not isinstance(container, dict) or container.get(field) is not expected:
+        errors.append(f"[{check}] {field} must be {str(expected).lower()}")
+
+
+def _artifact_by_path(evidence: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    artifacts = evidence.get("artifacts")
+    if not isinstance(artifacts, list):
+        return {}
+    result: dict[str, dict[str, Any]] = {}
+    for artifact in artifacts:
+        if isinstance(artifact, dict) and isinstance(artifact.get("path"), str):
+            result[artifact["path"]] = artifact
+    return result
+
+
+def validate_release_evidence(registry: Any, evidence: Any) -> list[str]:
+    """Return release-readiness errors for one normalized evidence document."""
+
+    errors: list[str] = []
+
+    posture_errors = source_posture.validate_registry_posture(registry)
+    if posture_errors:
+        return [f"[registry.posture] {error}" for error in posture_errors]
+
+    if not isinstance(evidence, dict):
+        return ["[evidence.shape] release evidence root must be an object"]
+    if evidence.get("schemaVersion") != 1:
+        errors.append("[evidence.schema] schemaVersion must be 1")
+
+    repository = evidence.get("repository")
+    if not isinstance(repository, str):
+        errors.append("[evidence.repository] repository must be an owner/name string")
+        return errors
+
+    registered = _repository_index(registry)
+    posture = registered.get(repository)
+    if posture is None:
+        errors.append(f"[evidence.repository] repository is not registered: {repository}")
+        return errors
+    if not source_posture.PRIMARY_FIELDS.issubset(posture):
+        errors.append(
+            f"[registry.unclassified] repository posture is not classified: {repository}"
+        )
+        return errors
+
+    distribution_mode = posture.get("distributionMode")
+    source_exposure = posture.get("sourceExposure")
+    visibility = posture.get("visibility")
+
+    release = evidence.get("release")
+    if not isinstance(release, dict):
+        errors.append("[release.shape] release must be an object")
+        release = {}
+
+    declared_release_authority = posture.get("releaseAuthority")
+    if isinstance(declared_release_authority, str):
+        if release.get("releaseAuthority") != declared_release_authority:
+            errors.append(
+                "[release.authority] evidence releaseAuthority must equal registry releaseAuthority "
+                f"{declared_release_authority}"
+            )
+
+    canonical_identity = release.get("canonicalIdentity")
+    if not isinstance(canonical_identity, str) or not canonical_identity:
+        errors.append("[release.identity] release.canonicalIdentity must be a non-empty string")
+    identity_claims = release.get("identityClaims", {})
+    if not isinstance(identity_claims, dict):
+        errors.append("[release.identity] release.identityClaims must be an object")
+    elif isinstance(canonical_identity, str) and canonical_identity:
+        for surface, value in sorted(identity_claims.items()):
+            if not isinstance(value, str) or value != canonical_identity:
+                errors.append(
+                    f"[release.identity] identity claim {surface!r} must equal canonical identity {canonical_identity!r}"
+                )
+
+    acquisition = evidence.get("acquisition")
+    if not isinstance(acquisition, dict):
+        errors.append("[acquisition.shape] acquisition must be an object")
+        acquisition = {}
+
+    acquisition_mode = acquisition.get("mode")
+    if distribution_mode in PUBLIC_DISTRIBUTION_MODES and acquisition_mode != distribution_mode:
+        errors.append(
+            f"[acquisition.mode] acquisition mode {acquisition_mode!r} contradicts registry distributionMode {distribution_mode!r}"
+        )
+
+    is_public_consumer_surface = visibility == "public" and distribution_mode in PUBLIC_DISTRIBUTION_MODES
+    if is_public_consumer_surface:
+        _require_bool(
+            acquisition,
+            "requiresPrivateCredentials",
+            False,
+            errors,
+            "acquisition.credentials",
+        )
+        _require_bool(acquisition, "immutable", True, errors, "acquisition.immutable")
+
+        clean_consumer = evidence.get("cleanConsumer")
+        _require_bool(clean_consumer, "tested", True, errors, "consumer.clean")
+        _require_bool(clean_consumer, "cacheMiss", True, errors, "consumer.clean")
+        _require_bool(
+            clean_consumer,
+            "privateCredentialsAvailable",
+            False,
+            errors,
+            "consumer.clean",
+        )
+        _require_bool(clean_consumer, "passed", True, errors, "consumer.clean")
+
+    if distribution_mode == "binary":
+        _require_bool(acquisition, "sourceBuild", False, errors, "binary.no-source-build")
+        pins = acquisition.get("cryptographicPins")
+        if not isinstance(pins, list) or not pins:
+            errors.append("[binary.pin] public binary acquisition requires at least one cryptographic pin")
+        elif any(not isinstance(pin, str) or not SHA256_RE.fullmatch(pin) for pin in pins):
+            errors.append("[binary.pin] cryptographicPins must contain canonical sha256:<64 lowercase hex> values")
+        if source_exposure == "public":
+            errors.append(
+                "[binary.exposure] binary distribution should not declare public implementation source exposure on the same surface"
+            )
+
+    if distribution_mode == "source":
+        _require_bool(acquisition, "sourceBuild", True, errors, "source.build")
+        if source_exposure != "public":
+            errors.append("[source.exposure] source distribution requires public source exposure")
+
+    inspection = evidence.get("inspection")
+    if not isinstance(inspection, dict):
+        errors.append("[artifact.inspection] inspection must be an object")
+        inspection = {}
+
+    for field, check in (
+        ("credentialsPresent", "artifact.credentials"),
+        ("signingKeysPresent", "artifact.signing-keys"),
+        ("privateSecurityCorpusPresent", "artifact.private-security-corpus"),
+        ("developmentOnlyMaterialPresent", "artifact.development-only"),
+    ):
+        _require_bool(inspection, field, False, errors, check)
+    if distribution_mode == "binary":
+        _require_bool(
+            inspection,
+            "privateImplementationSourcePresent",
+            False,
+            errors,
+            "binary.private-source",
+        )
+
+    cli = evidence.get("cli")
+    if cli is not None:
+        if not isinstance(cli, dict):
+            errors.append("[cli.shape] cli must be an object when present")
+        else:
+            artifacts = _artifact_by_path(evidence)
+            executable_path = cli.get("executablePath")
+            man_page_path = cli.get("manPagePath")
+            if not isinstance(executable_path, str) or executable_path not in artifacts:
+                errors.append("[cli.executable] cli executablePath must reference an inspected artifact")
+            elif artifacts[executable_path].get("executable") is not True:
+                errors.append("[cli.executable] CLI executable artifact must be executable")
+            if not isinstance(man_page_path, str) or man_page_path not in artifacts:
+                errors.append("[cli.man] cli manPagePath must reference an inspected artifact")
+            elif not man_page_path.startswith("share/man/man1/") or not man_page_path.endswith(".1"):
+                errors.append("[cli.man] section-1 man page must use share/man/man1/<name>.1")
+            _require_bool(cli, "smokePassed", True, errors, "cli.smoke")
+            _require_bool(cli, "operatorDocsPresent", True, errors, "cli.docs")
+
+    return errors
+
+
+def _read_json(path: Path, label: str) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"ERROR: {label} does not exist: {path}", file=sys.stderr)
+        raise SystemExit(2) from None
+    except json.JSONDecodeError as exc:
+        print(
+            f"ERROR: invalid JSON in {label} {path}: line {exc.lineno}, column {exc.colno}: {exc.msg}",
+            file=sys.stderr,
+        )
+        raise SystemExit(2) from exc
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("evidence", type=Path, help="normalized release-readiness evidence JSON")
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=Path("metadata/repositories.json"),
+        help="organization repository registry",
+    )
+    args = parser.parse_args()
+
+    registry = _read_json(args.registry, "registry")
+    evidence = _read_json(args.evidence, "release evidence")
+    errors = validate_release_evidence(registry, evidence)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Release readiness evidence matches declared posture for {evidence['repository']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements the first executable slice of #68 without duplicating repository-owned package/build logic.

## Changes

- add `tools/release_readiness.py`, a stdlib checker that consumes the existing repository registry plus normalized project-generated release evidence;
- add `metadata/release-readiness.schema.json` as the producer contract;
- document the release-evidence boundary and normalized identity model;
- add deterministic fixtures covering the required real topology shapes:
  - Invokrum-style private canonical + public binary distribution;
  - Repora public canonical/source distribution;
  - Keylix private canonical + public source projection;
  - Calathea public canonical reusable core;
- fail closed for binary source-build contradictions, private credential requirements, missing cryptographic pins, private implementation source in binary artifacts, credentials/signing/security-corpus/development material, CLI executable/man/smoke/docs gaps, release-authority mismatch, and normalized release-identity drift;
- require public consumer evidence to exercise a clean/cache-miss path with private credentials unavailable;
- include checker-only changes in meta-validation path triggers.

## Boundary

Repository-owned release tooling still builds and inspects the actual candidate. The organization checker consumes bounded normalized facts and never fetches caller-selected artifacts, receives signing authority, or becomes a language/package-specific parser.

Ordinary meta validation does not require a release candidate; unit tests make the checker implementation itself a required gate. A real project invokes the checker only when it has release evidence to validate.

## Deliberate follow-up

This PR does not yet add an exception engine or claim that Invokrum's not-yet-operational public binary distribution has produced real release evidence. Those remain follow-up acceptance work under #68 and the project migration issues.

Refs #68
Refs #66
Refs hackelia-micrantha/hackelia-micrantha#35