### PR TITLE
Skills: add public documentation sync with HITL ambiguity queue

### DIFF
--- a/docs/prompts/documentation/public-consistency-review.md
+++ b/docs/prompts/documentation/public-consistency-review.md
@@ -1,13 +1,15 @@
 # Public Documentation and Claims Consistency Review Prompt
 
-Use this prompt to reconcile websites, READMEs, books, one-pagers, whitepapers, screenshots, demos, and release messaging with current implementation and maturity.
+Use this prompt to reconcile websites, landing pages, READMEs, books, one-pagers, whitepapers, screenshots, demos, release messaging, and other public repository surfaces with current implementation and maturity.
 
-Do **not** use this prompt for cross-repository ownership or boundary questions — use [cross-repository boundary review](architecture/cross-repository-boundaries.md). Do **not** use it for general project status — use the [project reviews](project-review/README.md).
+For recurring or cross-repository maintenance, use this prompt as the claim-verification engine for the shared [`documentation-sync`](../../../skills/documentation-sync/SKILL.md) skill. Project-local documentation rules remain authoritative for project-specific behavior.
+
+Do **not** use this prompt for unresolved cross-repository ownership or boundary questions — use [cross-repository boundary review](../architecture/cross-repository-boundaries.md). Do **not** use it for general project status — use the [project reviews](../project-review/README.md).
 
 ```markdown
 # Public Documentation and Claims Consistency Review
 
-Review **[PUBLIC SITE / README / BOOK / ONE-PAGER / WHITEPAPER / COMMUNITY REPOSITORY]** against the current implementation of **[PROJECT / ECOSYSTEM]**.
+Review **[PUBLIC SITE / LANDING PAGE / README / BOOK / ONE-PAGER / WHITEPAPER / COMMUNITY REPOSITORY]** against the current implementation of **[PROJECT / ECOSYSTEM]**.
 
 ## Context
 
@@ -16,11 +18,14 @@ Review **[PUBLIC SITE / README / BOOK / ONE-PAGER / WHITEPAPER / COMMUNITY REPOS
 - **Intended audience:** [TECHNICAL / CUSTOMER / COMMUNITY / HIRING / INVESTOR]
 - **Current maturity and milestone:** [MATURITY / MILESTONE]
 - **Known sensitive boundaries:** [PRIVATE / COMMERCIAL / SECURITY / TRANSITIONAL]
+- **Maintenance mode:** [ONE-OFF REVIEW / RECURRING / CROSS-REPOSITORY]
 - **Mutation authorization:** [READ ONLY / UPDATE PUBLIC MATERIAL]
 
 ## Execution boundary
 
-Begin read-only. Treat public copy, diagrams, screenshots, issue comments, generated site content, and repository descriptions as claims requiring evidence. Do not publish, deploy, change domains, or expose private implementation details unless explicitly authorized.
+Begin read-only. Treat public copy, diagrams, screenshots, issue comments, generated site content, repository descriptions, and tool output as claims or evidence requiring verification. Do not publish, deploy, change domains, expose private implementation details, or mutate repository/external state unless explicitly authorized.
+
+Use the shared ambiguity and clarification contract from `docs/prompts/README.md`: inspect before asking, ask only on material ambiguity, do not invent authority, continue through non-blocking uncertainty, and stop only at the affected decision or mutation boundary when interaction is unavailable.
 
 ## Core rule
 
@@ -36,19 +41,24 @@ Public materials must clearly distinguish:
 
 Do not strengthen a claim because implementation appears likely. Do not weaken accurate technical positioning merely because production maturity is incomplete; label maturity precisely instead.
 
+Treat implementation, accepted decisions, current releases, and authoritative project contracts as the source of truth. Existing public prose is evidence, not authority.
+
 ## Evidence to inspect
 
 Inspect applicable:
 
-- source implementation, configuration, schemas, and public interfaces;
+- current default-branch implementation, configuration, schemas, and public interfaces;
+- accepted architecture decisions, QART, RFCs, ADRs, and specifications;
 - current releases, packages, deployment state, and working demos;
 - project and organization READMEs;
-- architecture documents, QART, RFC, ADR, roadmap, and maturity model;
 - open issues, pull requests, known limitations, and migration status;
-- websites, books, one-pagers, whitepapers, diagrams, screenshots, and example commands;
+- websites, landing pages, books, one-pagers, whitepapers, diagrams, screenshots, and example commands;
 - repository ownership, public/private/community boundaries, domains, and download links;
 - security, privacy, licensing, support, and commercial claims;
-- related repositories and integration testbeds.
+- related repositories and integration testbeds;
+- project-local documentation/skill guidance when present.
+
+Prefer exact current evidence over copied summaries, historical branches, or ambient green CI.
 
 ## Review dimensions
 
@@ -111,6 +121,8 @@ Require precise scope and evidence. Avoid absolute claims such as “secure,” 
 
 Confirm which components are open source, source-available, private, licensed, community, hosted, or commercial. Verify that public copy does not promise unavailable adapters, support, entitlements, or distribution channels.
 
+For private-canonical/public-distribution topologies, clearly distinguish implementation authority from the public artifact/package/community surface. Do not imply that a public distribution repository contains or authorizes private implementation source merely because it is the public install path.
+
 ### 8. Terminology and narrative consistency
 
 Identify inconsistent names, acronyms, maturity labels, architecture terms, goals, and calls to action across artifacts. Recommend one authoritative term and source.
@@ -120,6 +132,49 @@ Identify inconsistent names, acronyms, maturity labels, architecture terms, goal
 Review information hierarchy, readability, navigation, accessibility, visual consistency, code formatting, diagram legibility, responsive behavior, empty or broken sections, and whether the strongest verified outcome is visible early.
 
 Separate credibility or usability problems from cosmetic preference.
+
+## Recurring and cross-repository maintenance mode
+
+When reviewing a set of public repositories or running periodically:
+
+1. Establish the public surface inventory before editing: repository README, repository description/topics where accessible, docs entry points, landing/site source, release/install docs, generated references, package/community surfaces, and canonical external URLs.
+2. Resolve each project's documentation authority locally first. Shared guidance coordinates the review; it does not replace project-owned architecture, maturity, release, or security truth.
+3. Classify drift per repository, then reconcile cross-repository names, links, release paths, public/private roles, and shared terminology.
+4. Prefer updating canonical source content rather than generated output. If generated content drifts, fix its authoritative input or generator when feasible.
+5. Continue safe, unambiguous maintenance even when another repository has a blocked claim or decision.
+6. Track repeated drift patterns and recommend mechanical prevention: link checks, docs builds, generated CLI/API references, example tests, version checks, release-artifact verification, or other deterministic gates.
+7. Re-review affected rendered/public surfaces after changes. A source diff alone is not sufficient evidence for a landing page or generated site.
+
+The goal is not to make every repository say the same thing. The goal is for each public surface to say the smallest accurate thing supported by its owning project while remaining coherent with the wider ecosystem.
+
+## Human-in-the-loop ambiguity gate
+
+Do not ask humans to resolve questions that repository evidence can answer. When material ambiguity remains after inspection, aggregate it into a bounded **human decision queue** rather than interrupting piecemeal.
+
+A question belongs in the queue only when two or more plausible interpretations could materially change a public claim, ownership boundary, maturity statement, supported workflow, security/privacy statement, release/install path, destructive edit, or authorized mutation.
+
+For each question provide:
+
+| Field | Requirement |
+| --- | --- |
+| ID | Stable short identifier for the current review, such as `DOC-Q1` |
+| Question | One decision-oriented question, not a request for broad explanation |
+| Why it matters | The public claim, mutation, or boundary controlled by the answer |
+| Evidence/conflict | Current evidence and the specific unresolved contradiction or gap |
+| Options | Bounded plausible choices when known |
+| Recommended default | Preferred answer only when evidence supports one; otherwise `none` |
+| Blocked scope | Exact artifact/claim/mutation that must wait |
+| Safe continuation | Work that can continue without the answer |
+
+Use these dispositions:
+
+- **BLOCKING-WRITE** — do not mutate the affected source/public surface until answered.
+- **BLOCKING-CLAIM** — do not publish or strengthen the affected claim; unrelated edits may continue.
+- **FOLLOW-UP** — non-blocking uncertainty; state the working assumption and continue.
+
+Prefer a small set of high-information questions, normally grouped into 3–7 material decisions per pass when possible. Do not manufacture questions to reach a quota, and do not suppress additional questions when separate authority/security decisions genuinely require human disposition.
+
+If interaction is unavailable, finish all unaffected read-only analysis and authorized unambiguous edits, then return the queue. Never silently choose between conflicting authoritative sources.
 
 ## Finding classification
 
@@ -165,12 +220,21 @@ Provide dependency-ordered changes grouped as:
 
 For substantive wording changes, provide replacement copy. Avoid rewriting unaffected content.
 
-### G. Final assessment
+### G. Human decision queue
+
+List only unresolved material questions using the structured ambiguity format above. If none remain, state `No material human decisions required`.
+
+### H. Maintenance/prevention opportunities
+
+Identify repeated drift that can be reduced mechanically, with the owning repository and proposed validation/generation mechanism.
+
+### I. Final assessment
 
 Choose exactly one:
 
 - **Consistent and publishable**
 - **Publishable after minor corrections**
+- **Current with human decisions pending**
 - **Requires focused implementation/documentation reconciliation**
 - **Contains materially misleading claims**
 - **Requires architecture or ownership clarification**
@@ -185,7 +249,14 @@ When edits and publication are explicitly authorized:
 1. Correct misleading and stale claims first.
 2. Preserve established visual style unless a redesign is required for usability.
 3. Update authoritative source content rather than generated output where possible.
-4. Validate links, builds, and deployment previews.
-5. Re-review the rendered result on relevant form factors.
-6. Publish only through the established workflow and report the production URL or immutable artifact.
+4. Do not edit through a material human-decision boundary until it is resolved.
+5. Validate links, commands, examples, builds, documentation generation, and deployment previews as applicable.
+6. Re-review the rendered result on relevant form factors.
+7. Reconcile cross-repository links/names when the change affects ecosystem navigation or install paths.
+8. Publish only through the established workflow and report the production URL or immutable artifact when publication itself was authorized.
+9. Record unresolved material drift in the owning project's existing issue when possible; create a focused issue only when no suitable work item exists.
+
+## Completion
+
+The review is complete when every material public claim in scope is either supported, corrected, explicitly qualified, or represented in the human decision queue; authorized changes have been revalidated against current evidence; and unrelated work has not been blocked merely because one ambiguity remains.
 ```

--- a/skills/README.md
+++ b/skills/README.md
@@ -73,9 +73,12 @@ See [AI model selection and escalation](../docs/engineering/ai-model-selection.m
 | [`test-strategy`](test-strategy/SKILL.md) | Design risk-based layered validation and Testule integration |
 | [`security-review`](security-review/SKILL.md) | Review trust boundaries, abuse paths, privileges, and safe failure |
 | [`release-integration`](release-integration/SKILL.md) | Apply Micrantha release/distribution/integration strategy across repositories |
+| [`documentation-sync`](documentation-sync/SKILL.md) | Keep public documentation, landing pages, examples, links, and claims synchronized with current project truth while routing material ambiguity to a human decision queue |
 
 ## Execution rules
 
 The shared execution, ambiguity, validation, and priority contracts in [`docs/prompts/README.md`](../docs/prompts/README.md) apply to every shared skill unless a skill explicitly tightens them. A project-local skill should reference the organization standards that remain applicable and document intentional project-specific differences.
+
+For cross-project public documentation maintenance, `documentation-sync` coordinates evidence and consistency while project-local documentation/landing-page rules remain authoritative. The shared skill must not flatten different project maturity, release, or public/private topologies into one generic public narrative.
 
 Prefer durable mechanical controls over adding more prompt prose. When a recurring lesson can be enforced by a test, schema, type, CI gate, packaging check, capability boundary, or safer tool behavior, create or recommend that mechanism rather than relying on operator memory.

--- a/skills/documentation-sync/SKILL.md
+++ b/skills/documentation-sync/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: documentation-sync
+description: Keep public repository documentation, READMEs, landing pages, release/install guidance, and public claims synchronized with current implementation, maturity, and public/private boundaries while routing material ambiguity to a human decision queue.
+---
+
+# Documentation sync
+
+## Trigger
+
+Use for requests such as `keep public docs current`, `sync documentation`, `review docs/site claims across repos`, `maintain landing pages`, or recurring maintenance of public Micrantha repository surfaces.
+
+Use this skill when the goal is broader than a one-off wording review: the operator wants public surfaces reconciled with implementation repeatedly or across multiple repositories.
+
+## Inputs
+
+- one repository or a bounded repository set;
+- current repository visibility and role, without inferring implementation authority from visibility alone;
+- project-local documentation/landing-page guidance when present;
+- current default-branch implementation, accepted decisions, release/install path, and maturity evidence;
+- public surfaces in scope: README, docs entry points, landing/site source, repository description/topics where accessible, release/install docs, examples, generated references, package/community surfaces, and canonical external URLs;
+- mutation authorization if edits, commits, publication, deployment, issue updates, or external changes are requested.
+
+## Ownership model
+
+Resolve documentation behavior **project-local first**.
+
+- The owning project remains authoritative for its implementation, architecture, maturity, release path, security boundary, and project-specific documentation rules.
+- `hackelia-micrantha/.github` supplies the shared review/maintenance contract.
+- The Micrantha meta repository may inventory adoption and coordinate cross-project consistency; it must not become a second editable source of project documentation truth.
+- A public/community/distribution repository is not automatically the implementation authority.
+
+When a project has a local `documentation-sync` skill or equivalent contract, use it and treat this shared skill as the default/reference it specializes.
+
+## Workflow
+
+1. **Establish scope and inventory.** Identify the repositories and public surfaces actually in scope. For a cross-repository pass, start from an authoritative registry or explicit repository set rather than broadening opportunistically.
+2. **Resolve authority.** For each project, identify implementation authority, release/distribution authority, public surface ownership, project-local documentation rules, and applicable accepted decisions.
+3. **Establish current evidence.** Inspect current default-branch implementation, releases/artifacts, supported install path, public/private topology, open migrations, and material current issues/PRs that affect public truth.
+4. **Run claim reconciliation.** Apply `docs/prompts/documentation/public-consistency-review.md` to material public claims, links, examples, diagrams, maturity statements, security/privacy claims, and landing-page positioning.
+5. **Classify drift.** Separate misleading, stale, ambiguous, missing, inconsistent, and opportunity findings. Prefer the smallest truthful claim supported by current evidence.
+6. **Build the human decision queue.** Resolve ambiguity from evidence first. Aggregate only material unresolved decisions using the prompt's structured `DOC-Q*` format. Do not interrupt piecemeal when safe unrelated work can continue.
+7. **Apply bounded updates when authorized.** Correct canonical source content first; do not hand-edit generated output when its input/generator is the real source. Do not cross a `BLOCKING-WRITE` or `BLOCKING-CLAIM` decision boundary without human disposition.
+8. **Validate.** Re-run applicable link checks, docs/site builds, example or command tests, generated-reference checks, release/install verification, and rendered-page review. Validate the public/rendered result where the surface is a website or generated artifact.
+9. **Re-review.** Compare the resulting state against current implementation and the original findings. Confirm that edits did not create cross-repository naming, link, ownership, or release-path contradictions.
+10. **Track residual work.** Update an existing owning-project issue for implementation or documentation gaps when one exists; otherwise create the minimum focused follow-up. Keep human decisions distinct from ordinary implementation backlog.
+11. **Compound repeated drift.** Recommend deterministic prevention when recurrence is mechanically detectable: link checks, docs builds, generated CLI/API references, version checks, example tests, release-artifact verification, schema-derived reference, or similar gates.
+
+## Human-in-the-loop decision queue
+
+Questions are an output of evidence review, not a substitute for it.
+
+Only queue a question when unresolved ambiguity could materially change:
+
+- a public capability or maturity claim;
+- repository/component ownership or canonical source;
+- release/install/support path;
+- security, privacy, licensing, or distribution wording;
+- a destructive or externally visible edit;
+- an authorized mutation whose target or effect is not safely bounded.
+
+For each decision include:
+
+- stable short ID (`DOC-Q1`, `DOC-Q2`, ...);
+- one decision-oriented question;
+- why the answer matters;
+- evidence and the precise conflict/gap;
+- bounded options when known;
+- recommended default only when supported by evidence;
+- exact blocked artifact/claim/mutation;
+- safe work that can continue meanwhile;
+- disposition: `BLOCKING-WRITE`, `BLOCKING-CLAIM`, or `FOLLOW-UP`.
+
+Prefer a small high-information batch, normally 3–7 material questions per review pass when possible. Do not invent questions to fill a quota and do not collapse distinct authority/security decisions merely to reduce count.
+
+In unattended execution, continue all unambiguous read-only work and separately authorized safe mutations, then stop only at the affected decision boundary and return the queue.
+
+## Evidence
+
+A completed pass should identify, as applicable:
+
+- repository/default-branch revision inspected;
+- release/artifact/install evidence inspected;
+- public surfaces inspected;
+- project-local documentation authority used;
+- material claim dispositions;
+- changes made and their commit/PR evidence;
+- validation commands/checks and rendered/public verification;
+- unresolved human decisions and exact blocked scope;
+- follow-up issues or mechanical drift-prevention opportunities.
+
+Do not claim a public surface is current because CI is generally green or because a source edit appears plausible. Use evidence tied to the affected current revision and public contract.
+
+## Mutation boundary
+
+Read-only by default.
+
+When writes are explicitly authorized:
+
+- mutate only the repositories/surfaces in the approved scope;
+- prefer branch/PR workflows unless the project explicitly uses another path;
+- preserve project-local style and documentation architecture;
+- avoid exposing private implementation details or inaccessible internal links;
+- never treat a public repository's visibility as authorization to publish private source or internal operational detail;
+- do not publish/deploy merely because source edits were authorized unless publication/deployment was also authorized.
+
+## Completion
+
+Complete when:
+
+- every material public claim in scope is supported, corrected, explicitly qualified, or represented in the human decision queue;
+- authorized edits are validated against current implementation and, for sites/generated docs, the rendered result;
+- cross-repository names, links, public/private roles, and install/release paths are internally coherent for the reviewed scope;
+- unrelated work is not blocked by isolated ambiguity;
+- residual implementation/documentation gaps have an owning work item when needed;
+- repeated mechanically detectable drift has either a prevention recommendation or an explicit reason automation is not worthwhile.
+
+Valid final states are:
+
+- `CURRENT`
+- `CURRENT WITH FOLLOW-UPS`
+- `CURRENT WITH HUMAN DECISIONS PENDING`
+- `BLOCKED BY IMPLEMENTATION/DECISION`
+- `SIGNIFICANT DRIFT REMAINS`
+
+## References
+
+- `docs/prompts/documentation/public-consistency-review.md`
+- `docs/prompts/README.md#shared-ambiguity-and-clarification-contract`
+- `docs/prompts/architecture/cross-repository-boundaries.md`
+- `docs/prompts/project-review/comprehensive-status-review.md`
+- `docs/prompts/releases/release-readiness.md`
+- `docs/standards/source-exposure-and-distribution.md`
+- `docs/standards/testing.md`
+- `docs/standards/ci-cd.md`


### PR DESCRIPTION
## Outcome

Add a reusable `documentation-sync` shared skill for maintaining public READMEs, docs, landing pages, examples, install/release guidance, and public claims against current project truth.

## Key behavior

- project-local documentation authority remains primary;
- public/private/community repository visibility is not treated as implementation authority;
- the existing public consistency review becomes the claim-verification engine for recurring/cross-repository maintenance;
- material ambiguity is aggregated into a bounded human decision queue with evidence, options, recommended default when justified, exact blocked scope, and safe continuation;
- unattended passes continue unambiguous work and stop only at the affected mutation/claim boundary;
- repeated drift is routed toward deterministic prevention where practical.

## Changes

- add `skills/documentation-sync/SKILL.md`;
- register the skill in `skills/README.md`;
- extend `docs/prompts/documentation/public-consistency-review.md` with recurring maintenance mode and the HITL decision queue.

## Validation

- branch is based on current `main` at `fa9835a54d4c7f4898faa1df57765687ac484fb7`;
- relative links and ownership direction reviewed manually;
- no new prompt identity was introduced, so `docs/prompts/manifest.yaml` does not need a new entry;
- existing shared ambiguity contract remains authoritative and is tightened only for this workflow.
